### PR TITLE
Fix KeyError for force_mode when data_type is missing

### DIFF
--- a/custom_components/marstek_venus_energy_manager/coordinator.py
+++ b/custom_components/marstek_venus_energy_manager/coordinator.py
@@ -229,7 +229,7 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
             try:
                 value = await self.client.async_read_register(
                     register=sensor["register"],
-                    data_type=sensor["data_type"],
+                    data_type=sensor.get("data_type", "uint16"),
                     count=sensor.get("count"),
                     sensor_key=key,
                 )


### PR DESCRIPTION
Fixes error:
Error reading register 42010 for force_mode: 'data_type'

Adds default data_type (uint16) when missing.