### PR TITLE
fix: backup exclusion threshold and Active Batteries idle display

### DIFF
--- a/custom_components/marstek_venus_energy_manager/__init__.py
+++ b/custom_components/marstek_venus_energy_manager/__init__.py
@@ -569,8 +569,16 @@ class ChargeDischargeController:
         # Switch is ON. Check whether the battery is actively providing offgrid power.
         ac_offgrid = coordinator.data.get("ac_offgrid_power")
 
-        if ac_offgrid is not None and ac_offgrid == 0:
-            # Offgrid power is 0 — check if we are still within the post-backup cooldown
+        # Small permanent loads (e.g. a PoE switch, router, or AP connected to the
+        # offgrid port) should not trigger backup exclusion. Only a substantial load
+        # — indicative of a real grid-outage scenario — warrants excluding the battery
+        # from PD control. The threshold is set conservatively at 50 W; typical
+        # standby loads (switch + AP + cameras) are well below this, while a real
+        # backup load during a grid outage will exceed it noticeably.
+        BACKUP_OFFGRID_THRESHOLD_W = 50
+
+        if ac_offgrid is not None and ac_offgrid <= BACKUP_OFFGRID_THRESHOLD_W:
+            # Offgrid power is zero or a small standby load — check post-backup cooldown
             cooldown_until = self._backup_cooldown_until.get(coordinator)
             if cooldown_until and now < cooldown_until:
                 remaining = int((cooldown_until - now).total_seconds() / 60)
@@ -583,8 +591,13 @@ class ChargeDischargeController:
             self._backup_cooldown_until.pop(coordinator, None)
             return False
 
-        # Offgrid power > 0 (or sensor not available): backup is actively running.
+        # Offgrid power > threshold (or sensor not available): backup is actively running.
         # Refresh the cooldown window so it starts counting from the last active reading.
+        if ac_offgrid is not None:
+            _LOGGER.debug(
+                "%s: Backup active — offgrid load %.0fW exceeds %.0fW threshold, excluding from PD control",
+                coordinator.name, ac_offgrid, BACKUP_OFFGRID_THRESHOLD_W
+            )
         self._backup_cooldown_until[coordinator] = now + timedelta(minutes=5)
         return True
 
@@ -2446,7 +2459,17 @@ class ChargeDischargeController:
         - Power: Activate at 60%, deactivate at 50% (~100W hysteresis band)
         """
         if len(available_batteries) <= 1:
-            return list(available_batteries)
+            # Even with a single battery, update tracking state so the Active
+            # Batteries diagnostic sensor correctly reflects charging/discharging
+            # instead of always showing "Idle".
+            selected = list(available_batteries)
+            if is_charging:
+                self._active_charge_batteries = selected
+                self._active_discharge_batteries = []
+            else:
+                self._active_discharge_batteries = selected
+                self._active_charge_batteries = []
+            return selected
 
         # No power requested — clear state and return empty
         if total_power <= 0:


### PR DESCRIPTION
## Summary

Two bug fixes for multi-battery setups discovered during real-world use with two Marstek Venus batteries (V2 + V3), one of which has a PoE switch, AP, and cameras permanently connected to its offgrid port.

- **Fix `Active Batteries` sensor always showing `Idle` when only 1 battery is available** — `_select_batteries_for_operation` returned early for the single-battery case without updating the tracking lists, so the diagnostic sensor could never reflect the actual charging/discharging state. Closes #80

- **Fix battery with small permanent offgrid load being permanently excluded from PD control** — `_is_backup_function_active` refreshed the 5-minute cooldown every cycle whenever `ac_offgrid_power > 0`, making exclusion permanent for batteries with standby loads (router, switch, AP). A 50 W threshold now distinguishes small constant loads from a real grid-outage scenario. Closes #81

## Changes

### `_select_batteries_for_operation`

```python
# Before
if len(available_batteries) <= 1:
    return list(available_batteries)  # never updated _active_charge/discharge_batteries

# After
if len(available_batteries) <= 1:
    selected = list(available_batteries)
    if is_charging:
        self._active_charge_batteries = selected
        self._active_discharge_batteries = []
    else:
        self._active_discharge_batteries = selected
        self._active_charge_batteries = []
    return selected
```

### `_is_backup_function_active`

```python
# Before: any non-zero offgrid reading → permanent exclusion
if ac_offgrid is not None and ac_offgrid == 0:
    ...
    return False
self._backup_cooldown_until[coordinator] = now + timedelta(minutes=5)
return True

# After: only exclude when load exceeds 50 W threshold
BACKUP_OFFGRID_THRESHOLD_W = 50
if ac_offgrid is not None and ac_offgrid <= BACKUP_OFFGRID_THRESHOLD_W:
    ...
    return False
self._backup_cooldown_until[coordinator] = now + timedelta(minutes=5)
return True
```

## Test plan

- [ ] With two batteries and one excluded (SOC limits, hysteresis), verify `Active Batteries` sensor shows the correct battery name instead of `Idle`
- [ ] With backup function ON and a small permanent offgrid load (< 50 W), verify battery is included in PD control and charged/discharged normally
- [ ] With backup function ON and a substantial offgrid load (> 50 W, simulating a real outage), verify battery is correctly excluded from PD control
- [ ] Verify 5-minute cooldown still applies correctly after a real backup event ends and load drops below threshold

## Notes

The 50 W threshold is currently hardcoded. A follow-up improvement would be to expose it as a user-configurable option in the config flow, allowing users with heavier permanent offgrid loads to adjust it accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)