### PR TITLE
entity and device ids not specific enough (when having other services reading from modbus)

### DIFF
--- a/custom_components/marstek_venus_energy_manager/__init__.py
+++ b/custom_components/marstek_venus_energy_manager/__init__.py
@@ -4144,7 +4144,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except Exception as e:
             # Disconnect on any setup error
             await coordinator.disconnect()
-            raise ConfigEntryNotReady(f"Failed to set up {coordinator.host}: {e}") from e
+            raise ConfigEntryNotReady(f"Failed to set up {coordinator.host}:{coordinator.port}: {e}") from e
 
         coordinators.append(coordinator)
 

--- a/custom_components/marstek_venus_energy_manager/balance_sensors.py
+++ b/custom_components/marstek_venus_energy_manager/balance_sensors.py
@@ -104,7 +104,7 @@ class CellDeltaSensor(_BalanceBaseSensor):
     _attr_icon = "mdi:sine-wave"
 
     def __init__(self, coordinator: Any, init: dict) -> None:
-        self._attr_unique_id = f"{coordinator.host}_cell_delta"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_cell_delta"
         self._attr_native_value: float | None = None
         super().__init__(coordinator, init)
 
@@ -124,7 +124,7 @@ class BalanceStatusSensor(_BalanceBaseSensor):
     _attr_icon = "mdi:battery-heart-variant"
 
     def __init__(self, coordinator: Any, init: dict) -> None:
-        self._attr_unique_id = f"{coordinator.host}_balance_status"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_balance_status"
         self._status: str = "unknown"
         super().__init__(coordinator, init)
 
@@ -144,7 +144,7 @@ class DeltaTrendSensor(_BalanceBaseSensor):
     _attr_icon = "mdi:trending-up"
 
     def __init__(self, coordinator: Any, init: dict) -> None:
-        self._attr_unique_id = f"{coordinator.host}_delta_trend"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_delta_trend"
         self._trend: str = "unknown"
         super().__init__(coordinator, init)
 
@@ -165,7 +165,7 @@ class LastBalanceReadSensor(_BalanceBaseSensor):
     _attr_icon = "mdi:calendar-clock"
 
     def __init__(self, coordinator: Any, init: dict) -> None:
-        self._attr_unique_id = f"{coordinator.host}_last_balance_read"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_last_balance_read"
         self._ts: datetime | None = None
         super().__init__(coordinator, init)
 
@@ -198,7 +198,7 @@ class DeltaAvg4wSensor(_BalanceBaseSensor):
     _attr_icon = "mdi:chart-timeline-variant"
 
     def __init__(self, coordinator: Any, init: dict) -> None:
-        self._attr_unique_id = f"{coordinator.host}_delta_avg_4w"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_delta_avg_4w"
         self._avg: float | None = None
         super().__init__(coordinator, init)
 

--- a/custom_components/marstek_venus_energy_manager/binary_sensor.py
+++ b/custom_components/marstek_venus_energy_manager/binary_sensor.py
@@ -58,7 +58,7 @@ class MarstekVenusBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self.definition = definition
         
         self._attr_name = f"{coordinator.name} {definition['name']}"
-        self._attr_unique_id = f"{coordinator.host}_{definition['key']}"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_{definition['key']}"
         self._attr_device_class = definition.get("device_class")
         self._attr_icon = definition.get("icon")
         self._attr_entity_registry_enabled_default = definition.get("enabled_by_default", True)
@@ -77,7 +77,7 @@ class MarstekVenusBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def device_info(self):
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.host)},
+            "identifiers": {(DOMAIN, f"{self.coordinator.host}_{self.coordinator.port}")},
             "name": self.coordinator.name,
             "manufacturer": "Marstek",
             "model": "Venus",
@@ -98,7 +98,7 @@ class ChargeHysteresisActiveSensor(RestoreEntity, BinarySensorEntity):
 
         self._attr_has_entity_name = True
         self._attr_translation_key = "charge_hysteresis"
-        self._attr_unique_id = f"{coordinator.host}_charge_hysteresis_active"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_charge_hysteresis_active"
         self._attr_icon = "mdi:battery-lock"
         self._attr_should_poll = True
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -151,7 +151,7 @@ class ChargeHysteresisActiveSensor(RestoreEntity, BinarySensorEntity):
     def device_info(self):
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.host)},
+            "identifiers": {(DOMAIN, f"{self.coordinator.host}_{self.coordinator.port}")},
             "name": self.coordinator.name,
             "manufacturer": "Marstek",
             "model": "Venus",

--- a/custom_components/marstek_venus_energy_manager/button.py
+++ b/custom_components/marstek_venus_energy_manager/button.py
@@ -42,7 +42,7 @@ class MarstekVenusButton(ButtonEntity):
 
         self._attr_has_entity_name = True
         self._attr_translation_key = definition["key"]
-        self._attr_unique_id = f"{coordinator.host}_{definition['key']}"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_{definition['key']}"
         self._attr_icon = definition.get("icon")
         self._attr_device_class = definition.get("device_class")
         self._attr_entity_registry_enabled_default = definition.get("enabled_by_default", True)
@@ -58,7 +58,7 @@ class MarstekVenusButton(ButtonEntity):
     def device_info(self):
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.host)},
+            "identifiers": {(DOMAIN, f"{self.coordinator.host}_{self.coordinator.port}")},
             "name": self.coordinator.name,
             "manufacturer": "Marstek",
             "model": "Venus",

--- a/custom_components/marstek_venus_energy_manager/calculated_sensors.py
+++ b/custom_components/marstek_venus_energy_manager/calculated_sensors.py
@@ -42,7 +42,7 @@ class MarstekVenusEfficiencySensor(CoordinatorEntity, SensorEntity):
 
         self._attr_has_entity_name = True
         self._attr_translation_key = definition["key"]
-        self._attr_unique_id = f"{coordinator.host}_{definition['key']}"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_{definition['key']}"
         self._attr_device_class = definition.get("device_class")
         self._attr_state_class = definition.get("state_class")
         self._attr_native_unit_of_measurement = definition.get("unit")
@@ -73,7 +73,7 @@ class MarstekVenusEfficiencySensor(CoordinatorEntity, SensorEntity):
     def device_info(self):
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.host)},
+            "identifiers": {(DOMAIN, f"{self.coordinator.host}_{self.coordinator.port}")},
             "name": self.coordinator.name,
             "manufacturer": "Marstek",
             "model": "Venus",
@@ -92,7 +92,7 @@ class MarstekVenusStoredEnergySensor(CoordinatorEntity, SensorEntity):
 
         self._attr_has_entity_name = True
         self._attr_translation_key = definition["key"]
-        self._attr_unique_id = f"{coordinator.host}_{definition['key']}"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_{definition['key']}"
         self._attr_device_class = definition.get("device_class")
         self._attr_state_class = definition.get("state_class")
         self._attr_native_unit_of_measurement = definition.get("unit")
@@ -122,7 +122,7 @@ class MarstekVenusStoredEnergySensor(CoordinatorEntity, SensorEntity):
     def device_info(self):
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.host)},
+            "identifiers": {(DOMAIN, f"{self.coordinator.host}_{self.coordinator.port}")},
             "name": self.coordinator.name,
             "manufacturer": "Marstek",
             "model": "Venus",
@@ -141,7 +141,7 @@ class MarstekVenusCycleSensor(CoordinatorEntity, SensorEntity):
 
         self._attr_has_entity_name = True
         self._attr_translation_key = definition["key"]
-        self._attr_unique_id = f"{coordinator.host}_{definition['key']}"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_{definition['key']}"
         self._attr_state_class = definition.get("state_class")
         self._attr_icon = definition.get("icon")
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -167,7 +167,7 @@ class MarstekVenusCycleSensor(CoordinatorEntity, SensorEntity):
     def device_info(self):
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.host)},
+            "identifiers": {(DOMAIN, f"{self.coordinator.host}_{self.coordinator.port}")},
             "name": self.coordinator.name,
             "manufacturer": "Marstek",
             "model": "Venus",

--- a/custom_components/marstek_venus_energy_manager/number.py
+++ b/custom_components/marstek_venus_energy_manager/number.py
@@ -62,7 +62,7 @@ class MarstekVenusNumber(CoordinatorEntity, NumberEntity):
         
         self._attr_has_entity_name = True
         self._attr_translation_key = definition["key"]
-        self._attr_unique_id = f"{coordinator.host}_{definition['key']}"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_{definition['key']}"
         self._attr_icon = definition.get("icon")
         self._attr_native_unit_of_measurement = definition.get("unit")
         self._attr_native_min_value = definition["min"]
@@ -142,8 +142,8 @@ class MarstekVenusNumber(CoordinatorEntity, NumberEntity):
     def device_info(self):
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.host)},
-            "name": self.coordinator.name,
+            "identifiers": {(DOMAIN, f"{self.coordinator.host}_{self.coordinator.port}")},
+            "name": f"{self.coordinator.name}",
             "manufacturer": "Marstek",
             "model": "Venus",
         }
@@ -220,13 +220,13 @@ class MarstekSoftSocLimitNumber(CoordinatorEntity, NumberEntity):
         self._attr_should_poll = False
         if kind == "max":
             self._attr_translation_key = "charging_cutoff_capacity"
-            self._attr_unique_id = f"{coordinator.host}_charging_cutoff_capacity"
+            self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_charging_cutoff_capacity"
             self._attr_icon = "mdi:battery-arrow-up"
             self._attr_native_min_value = 50
             self._attr_native_max_value = 100
         else:
             self._attr_translation_key = "discharging_cutoff_capacity"
-            self._attr_unique_id = f"{coordinator.host}_discharging_cutoff_capacity"
+            self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_discharging_cutoff_capacity"
             self._attr_icon = "mdi:battery-arrow-down"
             self._attr_native_min_value = 5
             self._attr_native_max_value = 50
@@ -266,7 +266,7 @@ class MarstekSoftSocLimitNumber(CoordinatorEntity, NumberEntity):
     def device_info(self):
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.host)},
+            "identifiers": {(DOMAIN, f"{coordinator.host}_{coordinator.port}")},
             "name": self.coordinator.name,
             "manufacturer": "Marstek",
             "model": "Venus",
@@ -285,7 +285,7 @@ class MarstekBackupThresholdNumber(CoordinatorEntity, NumberEntity):
         super().__init__(coordinator)
         self._attr_has_entity_name = True
         self._attr_translation_key = "backup_offgrid_threshold"
-        self._attr_unique_id = f"{coordinator.host}_backup_offgrid_threshold"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_backup_offgrid_threshold"
         self._attr_icon = "mdi:transmission-tower-off"
         self._attr_native_unit_of_measurement = "W"
         self._attr_native_min_value = 0
@@ -312,7 +312,7 @@ class MarstekBackupThresholdNumber(CoordinatorEntity, NumberEntity):
     def device_info(self):
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.host)},
+            "identifiers": {(DOMAIN, f"{self.coordinator.host}_{self.coordinator.port}")},
             "name": self.coordinator.name,
             "manufacturer": "Marstek",
             "model": "Venus",

--- a/custom_components/marstek_venus_energy_manager/select.py
+++ b/custom_components/marstek_venus_energy_manager/select.py
@@ -52,7 +52,7 @@ class MarstekVenusSelect(CoordinatorEntity, SelectEntity):
         
         self._attr_has_entity_name = True
         self._attr_translation_key = definition["key"]
-        self._attr_unique_id = f"{coordinator.host}_{definition['key']}"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_{definition['key']}"
         self._attr_options = list(definition["options"].keys())
         self._attr_entity_registry_enabled_default = definition.get("enabled_by_default", True)
         self._attr_should_poll = False
@@ -87,7 +87,7 @@ class MarstekVenusSelect(CoordinatorEntity, SelectEntity):
     def device_info(self):
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.host)},
+            "identifiers": {(DOMAIN, f"{self.coordinator.host}_{self.coordinator.port}")},
             "name": self.coordinator.name,
             "manufacturer": "Marstek",
             "model": "Venus",

--- a/custom_components/marstek_venus_energy_manager/sensor.py
+++ b/custom_components/marstek_venus_energy_manager/sensor.py
@@ -159,7 +159,7 @@ class MarstekVenusSensor(CoordinatorEntity, SensorEntity):
         # Set entity attributes
         self._attr_has_entity_name = True
         self._attr_translation_key = definition["key"]
-        self._attr_unique_id = f"{coordinator.host}_{definition['key']}"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_{definition['key']}"
         self._attr_device_class = definition.get("device_class")
         self._attr_state_class = definition.get("state_class")
         self._attr_native_unit_of_measurement = definition.get("unit")
@@ -208,7 +208,7 @@ class MarstekVenusSensor(CoordinatorEntity, SensorEntity):
     def device_info(self):
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.host)},
+            "identifiers": {(DOMAIN, f"{self.coordinator.host}_{self.coordinator.port}")},
             "name": self.coordinator.name,
             "manufacturer": "Marstek",
             "model": "Venus",

--- a/custom_components/marstek_venus_energy_manager/switch.py
+++ b/custom_components/marstek_venus_energy_manager/switch.py
@@ -77,7 +77,7 @@ class MarstekVenusSwitch(CoordinatorEntity, SwitchEntity):
         
         self._attr_has_entity_name = True
         self._attr_translation_key = definition["key"]
-        self._attr_unique_id = f"{coordinator.host}_{definition['key']}"
+        self._attr_unique_id = f"{coordinator.host}_{coordinator.port}_{definition['key']}"
         self._attr_icon = definition.get("icon")
         self._attr_entity_registry_enabled_default = definition.get("enabled_by_default", True)
         self._attr_should_poll = False
@@ -112,7 +112,7 @@ class MarstekVenusSwitch(CoordinatorEntity, SwitchEntity):
     def device_info(self):
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.host)},
+            "identifiers": {(DOMAIN, f"{self.coordinator.host}_{self.coordinator.port}")},
             "name": self.coordinator.name,
             "manufacturer": "Marstek",
             "model": "Venus",


### PR DESCRIPTION
As most Modbus TCP devices allow only one client using their interface (and Marstek Venus E 3.0 definitely has this constraint), there maybe situations where it is needed to use some kind of proxy to bundle parallel requests from multiple clients (in my case: Marstek Venus Energy Manager and EVCC, https://github.com/evcc-io/evcc, which also provides the proxy). 
When that is the case, the different proxies are likely to reside on the same host, but are reachable via different ports. Then the host is not specific enough to construct a unique id for an entity, and the integration ends up constructing duplicate ids for each battery. Likewise, the device id is not specific enough and needs to also include the port (or any other property which differs). 
My proposal ist to base the ids on host and port, which works in my situation. 

Nevertheless: thank you very much for this awesome battery manager, which works like a charm! 