### PR TITLE
feat: load shedding via smart plugs for peak shaving

### DIFF
--- a/custom_components/marstek_venus_energy_manager/__init__.py
+++ b/custom_components/marstek_venus_energy_manager/__init__.py
@@ -67,6 +67,7 @@ from .const import (
     CONF_CAPACITY_PROTECTION_LIMIT,
     DEFAULT_CAPACITY_PROTECTION_SOC,
     DEFAULT_CAPACITY_PROTECTION_LIMIT,
+    CONF_LOAD_SHEDDING_ENABLED,
     CONF_MANUAL_MODE_ENABLED,
     CONF_PREDICTIVE_CHARGING_OVERRIDDEN,
     CONF_PREDICTIVE_CHARGING_MODE,
@@ -297,6 +298,7 @@ class ChargeDischargeController:
         self._predictive_safety_margin_kwh: float = config_entry.data.get(CONF_PREDICTIVE_SAFETY_MARGIN_KWH, DEFAULT_PREDICTIVE_SAFETY_MARGIN_KWH)
         self._charge_delay_unlocked = False       # True when delay has been unlocked today
         self._balance_monitor = None  # Set from async_setup_entry after monitor is created
+        self._load_shed_manager = None  # Set from async_setup_entry after manager is created
         self._charge_delay_last_date = None       # For daily reset
         self._charge_delay_forecast_cache = None  # Last forecast value used for balance check
         self._charge_delay_balance_needs_charge = True  # Cached balance result (conservative default)
@@ -3428,6 +3430,11 @@ class ChargeDischargeController:
             for coordinator in self.coordinators:
                 await self._balance_monitor.async_process(coordinator)
 
+        # === LOAD SHEDDING ===
+        # Run unconditionally so plugs are restored even when manual mode is active.
+        if self._load_shed_manager is not None:
+            await self._load_shed_manager.check()
+
         # === MANUAL MODE CHECK (highest priority) ===
         # If manual mode is enabled, skip all automatic control logic
         if self.manual_mode_enabled:
@@ -4385,12 +4392,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await balance_monitor.async_restore_coordinator(coordinator)
         controller._balance_monitor = balance_monitor
 
+    # Set up load shedding manager if enabled
+    load_shed_manager = None
+    if entry.data.get(CONF_LOAD_SHEDDING_ENABLED, False):
+        from .load_shed_manager import LoadSheddingManager
+        load_shed_manager = LoadSheddingManager(hass, entry)
+        controller._load_shed_manager = load_shed_manager
+        _LOGGER.info("Load Shedding: enabled (threshold=%dW, delay=%d min, plugs=%d)",
+                     entry.data.get("load_shedding_threshold", 2500),
+                     entry.data.get("load_shedding_duration_min", 7),
+                     len(entry.data.get("load_shedding_plugs", [])))
+
     hass.data[DOMAIN][entry.entry_id] = {
         "coordinators": coordinators,
         "controller": controller,
         "unsub_control": unsub_control,
         "unsub_refresh": unsub_refresh,
         "balance_monitor": balance_monitor,
+        "load_shed_manager": load_shed_manager,
     }
 
     # Listen for config entry updates so config entities refresh their state

--- a/custom_components/marstek_venus_energy_manager/config_flow.py
+++ b/custom_components/marstek_venus_energy_manager/config_flow.py
@@ -17,6 +17,8 @@ from homeassistant.helpers.selector import (
     NumberSelectorMode,
     EntitySelector,
     EntitySelectorConfig,
+    ServiceSelector,
+    ServiceSelectorConfig,
     TimeSelector,
     SelectSelector,
     SelectSelectorConfig,
@@ -71,6 +73,17 @@ from .const import (
     CONF_CAPACITY_PROTECTION_LIMIT,
     DEFAULT_CAPACITY_PROTECTION_SOC,
     DEFAULT_CAPACITY_PROTECTION_LIMIT,
+    CONF_LOAD_SHEDDING_ENABLED,
+    CONF_LOAD_SHEDDING_THRESHOLD,
+    CONF_LOAD_SHEDDING_DURATION_MIN,
+    CONF_LOAD_SHEDDING_MIN_PLUG_POWER,
+    CONF_LOAD_SHEDDING_PLUGS,
+    CONF_LOAD_SHEDDING_NOTIFY_ENABLED,
+    CONF_LOAD_SHEDDING_NOTIFY_TARGET,
+    DEFAULT_LOAD_SHEDDING_THRESHOLD,
+    DEFAULT_LOAD_SHEDDING_DURATION_MIN,
+    DEFAULT_LOAD_SHEDDING_MIN_PLUG_POWER,
+    DEFAULT_LOAD_SHEDDING_NOTIFY_ENABLED,
     CONF_PREDICTIVE_CHARGING_MODE,
     CONF_PRICE_SENSOR,
     CONF_PRICE_INTEGRATION_TYPE,
@@ -131,6 +144,7 @@ class MarstekVenusConfigFlow(ConfigFlow, domain=DOMAIN):
         self.battery_index = 0
         self.time_slots = []
         self.excluded_devices = []
+        self.load_shedding_plugs = []
         self._current_battery_data = {}  # Stores connection data between battery steps
 
     async def _test_connection(self, host: str, port: int, version: str = "v2") -> bool:
@@ -1052,9 +1066,7 @@ class MarstekVenusConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.config_data[CONF_PD_MIN_CHARGE_POWER] = DEFAULT_PD_MIN_CHARGE_POWER
                 self.config_data[CONF_PD_MIN_DISCHARGE_POWER] = DEFAULT_PD_MIN_DISCHARGE_POWER
                 self.config_data[CONF_TARGET_GRID_POWER] = DEFAULT_TARGET_GRID_POWER
-                return self.async_create_entry(
-                    title="Marstek Venus Energy Manager", data=self.config_data
-                )
+                return await self.async_step_load_shedding()
 
         return self.async_show_form(
             step_id="pd_advanced",
@@ -1078,9 +1090,7 @@ class MarstekVenusConfigFlow(ConfigFlow, domain=DOMAIN):
             self.config_data[CONF_PD_MIN_CHARGE_POWER] = user_input["pd_min_charge_power"]
             self.config_data[CONF_PD_MIN_DISCHARGE_POWER] = user_input["pd_min_discharge_power"]
             self.config_data[CONF_TARGET_GRID_POWER] = user_input["pd_target_grid_power"]
-            return self.async_create_entry(
-                title="Marstek Venus Energy Manager", data=self.config_data
-            )
+            return await self.async_step_load_shedding()
 
         return self.async_show_form(
             step_id="pd_advanced_config",
@@ -1144,6 +1154,133 @@ class MarstekVenusConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
         )
 
+    async def async_step_load_shedding(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Ask if the user wants to enable load shedding."""
+        if user_input is not None:
+            if user_input.get("enable_load_shedding", False):
+                return await self.async_step_load_shedding_config()
+            else:
+                self.config_data[CONF_LOAD_SHEDDING_ENABLED] = False
+                self.config_data[CONF_LOAD_SHEDDING_PLUGS] = []
+                return self.async_create_entry(
+                    title="Marstek Venus Energy Manager", data=self.config_data
+                )
+
+        return self.async_show_form(
+            step_id="load_shedding",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("enable_load_shedding", default=False): BooleanSelector(),
+                }
+            ),
+            description_placeholders={
+                "description": (
+                    "Automatically switch off nominated smart plugs when sustained grid draw "
+                    "exceeds the peak threshold. Plugs are restored when the situation clears."
+                )
+            },
+        )
+
+    async def async_step_load_shedding_config(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Configure load shedding parameters."""
+        if user_input is not None:
+            self.config_data[CONF_LOAD_SHEDDING_ENABLED] = True
+            self.config_data[CONF_LOAD_SHEDDING_THRESHOLD] = int(user_input["load_shedding_threshold"])
+            self.config_data[CONF_LOAD_SHEDDING_DURATION_MIN] = int(user_input["load_shedding_duration_min"])
+            self.config_data[CONF_LOAD_SHEDDING_MIN_PLUG_POWER] = int(user_input["load_shedding_min_plug_power"])
+            self.config_data[CONF_LOAD_SHEDDING_NOTIFY_ENABLED] = user_input.get("load_shedding_notify_enabled", DEFAULT_LOAD_SHEDDING_NOTIFY_ENABLED)
+            self.config_data[CONF_LOAD_SHEDDING_NOTIFY_TARGET] = user_input.get("load_shedding_notify_target") or ""
+            self.load_shedding_plugs = []
+            return await self.async_step_add_load_shedding_plug()
+
+        return self.async_show_form(
+            step_id="load_shedding_config",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("load_shedding_threshold", default=DEFAULT_LOAD_SHEDDING_THRESHOLD):
+                        NumberSelector(
+                            NumberSelectorConfig(
+                                min=1000, max=15000, step=100,
+                                mode=NumberSelectorMode.SLIDER,
+                                unit_of_measurement="W",
+                            )
+                        ),
+                    vol.Required("load_shedding_duration_min", default=DEFAULT_LOAD_SHEDDING_DURATION_MIN):
+                        NumberSelector(
+                            NumberSelectorConfig(
+                                min=1, max=14, step=1,
+                                mode=NumberSelectorMode.SLIDER,
+                                unit_of_measurement="min",
+                            )
+                        ),
+                    vol.Required("load_shedding_min_plug_power", default=DEFAULT_LOAD_SHEDDING_MIN_PLUG_POWER):
+                        NumberSelector(
+                            NumberSelectorConfig(
+                                min=10, max=1000, step=10,
+                                mode=NumberSelectorMode.SLIDER,
+                                unit_of_measurement="W",
+                            )
+                        ),
+                    vol.Required("load_shedding_notify_enabled", default=DEFAULT_LOAD_SHEDDING_NOTIFY_ENABLED):
+                        BooleanSelector(),
+                    vol.Optional("load_shedding_notify_target"):
+                        ServiceSelector(ServiceSelectorConfig(domain="notify")),
+                }
+            ),
+        )
+
+    async def async_step_add_load_shedding_plug(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Add a smart plug to the load shedding list."""
+        plug_num = len(self.load_shedding_plugs) + 1
+        if user_input is not None:
+            self.load_shedding_plugs.append({
+                "switch_entity": user_input["switch_entity"],
+                "power_sensor": user_input.get("power_sensor") or "",
+            })
+            return await self.async_step_add_more_load_shedding_plugs()
+
+        return self.async_show_form(
+            step_id="add_load_shedding_plug",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("switch_entity"):
+                        EntitySelector(EntitySelectorConfig(domain="switch")),
+                    vol.Optional("power_sensor"):
+                        EntitySelector(EntitySelectorConfig(domain="sensor")),
+                }
+            ),
+            description_placeholders={"plug_num": str(plug_num)},
+        )
+
+    async def async_step_add_more_load_shedding_plugs(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Ask whether to add another plug."""
+        if user_input is not None:
+            if user_input.get("add_another", False):
+                return await self.async_step_add_load_shedding_plug()
+            else:
+                self.config_data[CONF_LOAD_SHEDDING_PLUGS] = self.load_shedding_plugs
+                return self.async_create_entry(
+                    title="Marstek Venus Energy Manager", data=self.config_data
+                )
+
+        return self.async_show_form(
+            step_id="add_more_load_shedding_plugs",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("add_another", default=False): BooleanSelector(),
+                }
+            ),
+            description_placeholders={"count": str(len(self.load_shedding_plugs))},
+        )
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
@@ -1160,6 +1297,7 @@ class OptionsFlowHandler(OptionsFlow):
         self.battery_index = 0
         self.time_slots = []
         self.excluded_devices = []
+        self.load_shedding_plugs = []
         self._current_battery_data = {}  # Stores connection data between battery steps
         _LOGGER.info("OptionsFlowHandler initialized successfully for entry: %s", config_entry.entry_id)
 
@@ -1267,6 +1405,7 @@ class OptionsFlowHandler(OptionsFlow):
                 "weekly_full_charge",
                 "charge_delay",
                 "capacity_protection",
+                "load_shedding",
                 "pd_advanced",
             ],
         )
@@ -2445,4 +2584,118 @@ class OptionsFlowHandler(OptionsFlow):
                     "**Target Grid Power**: Grid power setpoint (W) the controller regulates to. Negative = export to grid, positive = import from grid, 0 = net zero."
                 )
             },
+        )
+
+    async def async_step_load_shedding(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Ask if the user wants to enable load shedding."""
+        is_enabled = self.config_entry.data.get(CONF_LOAD_SHEDDING_ENABLED, False)
+
+        if user_input is not None:
+            if user_input.get("enable_load_shedding", False):
+                return await self.async_step_load_shedding_config()
+            else:
+                self.config_data[CONF_LOAD_SHEDDING_ENABLED] = False
+                self.config_data[CONF_LOAD_SHEDDING_PLUGS] = []
+                return await self._save_and_finish()
+
+        return self.async_show_form(
+            step_id="load_shedding",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("enable_load_shedding", default=is_enabled): BooleanSelector(),
+                }
+            ),
+            description_placeholders={
+                "description": (
+                    "Automatically switch off nominated smart plugs when sustained grid draw "
+                    "exceeds the peak threshold. Plugs are restored when the situation clears."
+                )
+            },
+        )
+
+    async def async_step_load_shedding_config(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Configure load shedding parameters."""
+        existing = self.config_entry.data
+        cur_threshold = existing.get(CONF_LOAD_SHEDDING_THRESHOLD, DEFAULT_LOAD_SHEDDING_THRESHOLD)
+        cur_duration = existing.get(CONF_LOAD_SHEDDING_DURATION_MIN, DEFAULT_LOAD_SHEDDING_DURATION_MIN)
+        cur_min_power = existing.get(CONF_LOAD_SHEDDING_MIN_PLUG_POWER, DEFAULT_LOAD_SHEDDING_MIN_PLUG_POWER)
+        cur_notify = existing.get(CONF_LOAD_SHEDDING_NOTIFY_ENABLED, DEFAULT_LOAD_SHEDDING_NOTIFY_ENABLED)
+        cur_target = existing.get(CONF_LOAD_SHEDDING_NOTIFY_TARGET, "")
+
+        if user_input is not None:
+            self.config_data[CONF_LOAD_SHEDDING_ENABLED] = True
+            self.config_data[CONF_LOAD_SHEDDING_THRESHOLD] = int(user_input["load_shedding_threshold"])
+            self.config_data[CONF_LOAD_SHEDDING_DURATION_MIN] = int(user_input["load_shedding_duration_min"])
+            self.config_data[CONF_LOAD_SHEDDING_MIN_PLUG_POWER] = int(user_input["load_shedding_min_plug_power"])
+            self.config_data[CONF_LOAD_SHEDDING_NOTIFY_ENABLED] = user_input.get("load_shedding_notify_enabled", DEFAULT_LOAD_SHEDDING_NOTIFY_ENABLED)
+            self.config_data[CONF_LOAD_SHEDDING_NOTIFY_TARGET] = user_input.get("load_shedding_notify_target") or ""
+            self.load_shedding_plugs = []
+            return await self.async_step_add_load_shedding_plug()
+
+        schema: dict = {
+            vol.Required("load_shedding_threshold", default=cur_threshold):
+                NumberSelector(NumberSelectorConfig(min=1000, max=15000, step=100, mode=NumberSelectorMode.SLIDER, unit_of_measurement="W")),
+            vol.Required("load_shedding_duration_min", default=cur_duration):
+                NumberSelector(NumberSelectorConfig(min=1, max=14, step=1, mode=NumberSelectorMode.SLIDER, unit_of_measurement="min")),
+            vol.Required("load_shedding_min_plug_power", default=cur_min_power):
+                NumberSelector(NumberSelectorConfig(min=10, max=1000, step=10, mode=NumberSelectorMode.SLIDER, unit_of_measurement="W")),
+            vol.Required("load_shedding_notify_enabled", default=cur_notify):
+                BooleanSelector(),
+            vol.Optional("load_shedding_notify_target", description={"suggested_value": cur_target} if cur_target else {}):
+                ServiceSelector(ServiceSelectorConfig(domain="notify")),
+        }
+
+        return self.async_show_form(
+            step_id="load_shedding_config",
+            data_schema=vol.Schema(schema),
+        )
+
+    async def async_step_add_load_shedding_plug(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Add a smart plug to the load shedding list."""
+        plug_num = len(self.load_shedding_plugs) + 1
+        if user_input is not None:
+            self.load_shedding_plugs.append({
+                "switch_entity": user_input["switch_entity"],
+                "power_sensor": user_input.get("power_sensor") or "",
+            })
+            return await self.async_step_add_more_load_shedding_plugs()
+
+        return self.async_show_form(
+            step_id="add_load_shedding_plug",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("switch_entity"):
+                        EntitySelector(EntitySelectorConfig(domain="switch")),
+                    vol.Optional("power_sensor"):
+                        EntitySelector(EntitySelectorConfig(domain="sensor")),
+                }
+            ),
+            description_placeholders={"plug_num": str(plug_num)},
+        )
+
+    async def async_step_add_more_load_shedding_plugs(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Ask whether to add another plug."""
+        if user_input is not None:
+            if user_input.get("add_another", False):
+                return await self.async_step_add_load_shedding_plug()
+            else:
+                self.config_data[CONF_LOAD_SHEDDING_PLUGS] = self.load_shedding_plugs
+                return await self._save_and_finish()
+
+        return self.async_show_form(
+            step_id="add_more_load_shedding_plugs",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("add_another", default=False): BooleanSelector(),
+                }
+            ),
+            description_placeholders={"count": str(len(self.load_shedding_plugs))},
         )

--- a/custom_components/marstek_venus_energy_manager/config_flow.py
+++ b/custom_components/marstek_venus_energy_manager/config_flow.py
@@ -17,8 +17,6 @@ from homeassistant.helpers.selector import (
     NumberSelectorMode,
     EntitySelector,
     EntitySelectorConfig,
-    ServiceSelector,
-    ServiceSelectorConfig,
     TimeSelector,
     SelectSelector,
     SelectSelectorConfig,
@@ -1228,7 +1226,7 @@ class MarstekVenusConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Required("load_shedding_notify_enabled", default=DEFAULT_LOAD_SHEDDING_NOTIFY_ENABLED):
                         BooleanSelector(),
                     vol.Optional("load_shedding_notify_target"):
-                        ServiceSelector(ServiceSelectorConfig(domain="notify")),
+                        TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
                 }
             ),
         )
@@ -2646,7 +2644,7 @@ class OptionsFlowHandler(OptionsFlow):
             vol.Required("load_shedding_notify_enabled", default=cur_notify):
                 BooleanSelector(),
             vol.Optional("load_shedding_notify_target", description={"suggested_value": cur_target} if cur_target else {}):
-                ServiceSelector(ServiceSelectorConfig(domain="notify")),
+                TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
         }
 
         return self.async_show_form(

--- a/custom_components/marstek_venus_energy_manager/const.py
+++ b/custom_components/marstek_venus_energy_manager/const.py
@@ -1856,6 +1856,20 @@ CONF_CAPACITY_PROTECTION_LIMIT = "capacity_protection_limit"
 DEFAULT_CAPACITY_PROTECTION_SOC = 30
 DEFAULT_CAPACITY_PROTECTION_LIMIT = 2500
 
+# Load Shedding Configuration
+CONF_LOAD_SHEDDING_ENABLED = "load_shedding_enabled"
+CONF_LOAD_SHEDDING_THRESHOLD = "load_shedding_threshold"
+CONF_LOAD_SHEDDING_DURATION_MIN = "load_shedding_duration_min"
+CONF_LOAD_SHEDDING_MIN_PLUG_POWER = "load_shedding_min_plug_power"
+CONF_LOAD_SHEDDING_PLUGS = "load_shedding_plugs"
+CONF_LOAD_SHEDDING_NOTIFY_ENABLED = "load_shedding_notify_enabled"
+CONF_LOAD_SHEDDING_NOTIFY_TARGET = "load_shedding_notify_target"
+
+DEFAULT_LOAD_SHEDDING_THRESHOLD = 2500
+DEFAULT_LOAD_SHEDDING_DURATION_MIN = 7
+DEFAULT_LOAD_SHEDDING_MIN_PLUG_POWER = 100
+DEFAULT_LOAD_SHEDDING_NOTIFY_ENABLED = True
+
 # PD Controller Advanced Configuration Keys
 CONF_PD_KP = "pd_controller_kp"
 CONF_PD_KD = "pd_controller_kd"

--- a/custom_components/marstek_venus_energy_manager/load_shed_manager.py
+++ b/custom_components/marstek_venus_energy_manager/load_shed_manager.py
@@ -1,0 +1,159 @@
+"""Load shedding manager for peak shaving via smart plugs.
+
+When sustained grid draw exceeds the configured threshold for longer than
+the trigger delay, nominated smart plugs are switched off in order until
+the excess is covered. They are restored automatically when grid draw drops
+back below the threshold.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    CONF_LOAD_SHEDDING_THRESHOLD,
+    CONF_LOAD_SHEDDING_DURATION_MIN,
+    CONF_LOAD_SHEDDING_MIN_PLUG_POWER,
+    CONF_LOAD_SHEDDING_PLUGS,
+    CONF_LOAD_SHEDDING_NOTIFY_ENABLED,
+    CONF_LOAD_SHEDDING_NOTIFY_TARGET,
+    DEFAULT_LOAD_SHEDDING_THRESHOLD,
+    DEFAULT_LOAD_SHEDDING_DURATION_MIN,
+    DEFAULT_LOAD_SHEDDING_MIN_PLUG_POWER,
+    DEFAULT_LOAD_SHEDDING_NOTIFY_ENABLED,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class LoadSheddingManager:
+    """Switches off nominated plugs when grid draw stays above threshold too long."""
+
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+        self._hass = hass
+        self._consumption_sensor: str = config_entry.data["consumption_sensor"]
+        self._threshold: float = config_entry.data.get(CONF_LOAD_SHEDDING_THRESHOLD, DEFAULT_LOAD_SHEDDING_THRESHOLD)
+        self._duration_s: float = config_entry.data.get(CONF_LOAD_SHEDDING_DURATION_MIN, DEFAULT_LOAD_SHEDDING_DURATION_MIN) * 60
+        self._min_plug_power: float = config_entry.data.get(CONF_LOAD_SHEDDING_MIN_PLUG_POWER, DEFAULT_LOAD_SHEDDING_MIN_PLUG_POWER)
+        self._plugs: list[dict] = config_entry.data.get(CONF_LOAD_SHEDDING_PLUGS, [])
+        self._notify_enabled: bool = config_entry.data.get(CONF_LOAD_SHEDDING_NOTIFY_ENABLED, DEFAULT_LOAD_SHEDDING_NOTIFY_ENABLED)
+        self._notify_target: str = config_entry.data.get(CONF_LOAD_SHEDDING_NOTIFY_TARGET, "") or ""
+
+        self._above_threshold_since: datetime | None = None
+        self._shedding_active: bool = False
+        self._shed_plugs: list[str] = []
+
+    async def check(self) -> None:
+        """Read grid power and trigger or restore shedding as needed. Called every 2 s."""
+        state = self._hass.states.get(self._consumption_sensor)
+        if state is None or state.state in ("unknown", "unavailable"):
+            return
+
+        try:
+            grid_power = float(state.state)
+        except ValueError:
+            return
+
+        if grid_power > self._threshold:
+            if self._above_threshold_since is None:
+                self._above_threshold_since = dt_util.utcnow()
+                return
+
+            elapsed = (dt_util.utcnow() - self._above_threshold_since).total_seconds()
+            if elapsed >= self._duration_s and not self._shedding_active:
+                await self._trigger_shedding(grid_power)
+        else:
+            if self._shedding_active:
+                await self._restore_plugs()
+            self._above_threshold_since = None
+
+    async def _trigger_shedding(self, grid_power: float) -> None:
+        """Switch off plugs in order until grid excess is covered."""
+        excess = grid_power - self._threshold
+        shed: list[str] = []
+
+        for plug in self._plugs:
+            if excess <= 0:
+                break
+
+            switch_entity = plug.get("switch_entity")
+            power_sensor = plug.get("power_sensor")
+            if not switch_entity:
+                continue
+
+            plug_power = 0.0
+            if power_sensor:
+                ps = self._hass.states.get(power_sensor)
+                if ps is not None and ps.state not in ("unknown", "unavailable"):
+                    try:
+                        plug_power = float(ps.state)
+                    except ValueError:
+                        pass
+
+            if plug_power < self._min_plug_power:
+                _LOGGER.debug("Load shedding: skipping %s (%.0fW < %.0fW min)", switch_entity, plug_power, self._min_plug_power)
+                continue
+
+            await self._hass.services.async_call(
+                "switch", "turn_off", {"entity_id": switch_entity}
+            )
+            shed.append(switch_entity)
+            excess -= plug_power
+            _LOGGER.info("Load shedding: switched off %s (%.0fW), remaining excess %.0fW", switch_entity, plug_power, max(0, excess))
+
+        if shed:
+            self._shedding_active = True
+            self._shed_plugs = shed
+            await self._send_notification(
+                "shed",
+                f"Grid draw {grid_power:.0f}W exceeded {self._threshold:.0f}W threshold "
+                f"for >{self._duration_s / 60:.0f} min.\nSwitched off: {', '.join(shed)}",
+            )
+        else:
+            _LOGGER.warning("Load shedding triggered but no eligible plugs found (all below %.0fW threshold)", self._min_plug_power)
+
+    async def _restore_plugs(self) -> None:
+        """Restore all shed plugs and notify."""
+        for switch_entity in self._shed_plugs:
+            await self._hass.services.async_call(
+                "switch", "turn_on", {"entity_id": switch_entity}
+            )
+            _LOGGER.info("Load shedding: restored %s", switch_entity)
+
+        await self._send_notification(
+            "restore",
+            f"Grid draw returned below {self._threshold:.0f}W threshold.\nRestored: {', '.join(self._shed_plugs)}",
+        )
+        self._shedding_active = False
+        self._shed_plugs = []
+
+    async def _send_notification(self, action: str, message: str) -> None:
+        """Send persistent HA notification and optionally a push notification."""
+        if not self._notify_enabled:
+            return
+
+        title = "⚡ Peak load shedding active" if action == "shed" else "✅ Peak load shedding resolved"
+
+        await self._hass.services.async_call(
+            "persistent_notification",
+            "create",
+            {
+                "title": title,
+                "message": message,
+                "notification_id": "marstek_load_shedding",
+            },
+        )
+
+        if self._notify_target:
+            parts = self._notify_target.split(".", 1)
+            if len(parts) == 2:
+                try:
+                    await self._hass.services.async_call(
+                        parts[0], parts[1], {"title": title, "message": message}
+                    )
+                except Exception as e:
+                    _LOGGER.warning("Load shedding: failed to send notification to %s: %s", self._notify_target, e)

--- a/custom_components/marstek_venus_energy_manager/strings.json
+++ b/custom_components/marstek_venus_energy_manager/strings.json
@@ -213,6 +213,52 @@
           "capacity_protection_soc_threshold": "Cuando el SOC medio de las baterías baje de este valor, se activa la reducción de picos. La batería dejará de descargar para consumo normal y solo cubrirá picos por encima del límite.",
           "capacity_protection_limit": "Umbral de potencia de importación de red. Cuando el consumo de la casa supere este valor y la reducción de picos esté activa, la batería solo descargará el exceso por encima de este límite."
         }
+      },
+      "load_shedding": {
+        "title": "Load Shedding",
+        "description": "Automatically switch off high-power plugs when grid draw exceeds the peak threshold for too long. Plugs are restored when the situation clears.",
+        "data": {
+          "enable_load_shedding": "Enable load shedding"
+        },
+        "data_description": {
+          "enable_load_shedding": "When enabled, nominated smart plugs will be switched off if sustained grid draw exceeds the threshold."
+        }
+      },
+      "load_shedding_config": {
+        "title": "Load Shedding — Settings",
+        "data": {
+          "load_shedding_threshold": "Peak threshold (W)",
+          "load_shedding_duration_min": "Trigger delay (minutes)",
+          "load_shedding_min_plug_power": "Minimum plug power to shed (W)",
+          "load_shedding_notify_enabled": "Enable notifications",
+          "load_shedding_notify_target": "Notification target (optional)"
+        },
+        "data_description": {
+          "load_shedding_threshold": "Grid draw above this level triggers the countdown. Default: 2500 W.",
+          "load_shedding_duration_min": "Minutes of sustained overload before plugs are switched off. Default: 7 min.",
+          "load_shedding_min_plug_power": "Only shed plugs currently drawing at least this much power. Default: 100 W.",
+          "load_shedding_notify_enabled": "Send a notification when plugs are switched off or restored.",
+          "load_shedding_notify_target": "Optional: select a notify service (e.g. mobile app) to receive push notifications in addition to the HA dashboard notification."
+        }
+      },
+      "add_load_shedding_plug": {
+        "title": "Add Plug #{plug_num}",
+        "description": "Select the switch entity for this plug. Plugs are shed in the order they are added.",
+        "data": {
+          "switch_entity": "Switch entity",
+          "power_sensor": "Power sensor (optional)"
+        },
+        "data_description": {
+          "switch_entity": "The switch entity that controls this plug.",
+          "power_sensor": "Optional power sensor. Used to check if the plug draws enough power to be worth shedding."
+        }
+      },
+      "add_more_load_shedding_plugs": {
+        "title": "Add Another Plug?",
+        "description": "{count} plug(s) configured so far.",
+        "data": {
+          "add_another": "Add another plug"
+        }
       }
     },
     "error": {
@@ -408,6 +454,52 @@
         "data_description": {
           "capacity_protection_soc_threshold": "Cuando el SOC medio de las baterías baje de este valor, se activa la reducción de picos. La batería dejará de descargar para consumo normal y solo cubrirá picos por encima del límite.",
           "capacity_protection_limit": "Umbral de potencia de importación de red. Cuando el consumo de la casa supere este valor y la reducción de picos esté activa, la batería solo descargará el exceso por encima de este límite."
+        }
+      },
+      "load_shedding": {
+        "title": "Load Shedding",
+        "description": "Automatically switch off high-power plugs when grid draw exceeds the peak threshold for too long. Plugs are restored when the situation clears.",
+        "data": {
+          "enable_load_shedding": "Enable load shedding"
+        },
+        "data_description": {
+          "enable_load_shedding": "When enabled, nominated smart plugs will be switched off if sustained grid draw exceeds the threshold."
+        }
+      },
+      "load_shedding_config": {
+        "title": "Load Shedding — Settings",
+        "data": {
+          "load_shedding_threshold": "Peak threshold (W)",
+          "load_shedding_duration_min": "Trigger delay (minutes)",
+          "load_shedding_min_plug_power": "Minimum plug power to shed (W)",
+          "load_shedding_notify_enabled": "Enable notifications",
+          "load_shedding_notify_target": "Notification target (optional)"
+        },
+        "data_description": {
+          "load_shedding_threshold": "Grid draw above this level triggers the countdown. Default: 2500 W.",
+          "load_shedding_duration_min": "Minutes of sustained overload before plugs are switched off. Default: 7 min.",
+          "load_shedding_min_plug_power": "Only shed plugs currently drawing at least this much power. Default: 100 W.",
+          "load_shedding_notify_enabled": "Send a notification when plugs are switched off or restored.",
+          "load_shedding_notify_target": "Optional: select a notify service (e.g. mobile app) to receive push notifications in addition to the HA dashboard notification."
+        }
+      },
+      "add_load_shedding_plug": {
+        "title": "Add Plug #{plug_num}",
+        "description": "Select the switch entity for this plug. Plugs are shed in the order they are added.",
+        "data": {
+          "switch_entity": "Switch entity",
+          "power_sensor": "Power sensor (optional)"
+        },
+        "data_description": {
+          "switch_entity": "The switch entity that controls this plug.",
+          "power_sensor": "Optional power sensor. Used to check if the plug draws enough power to be worth shedding."
+        }
+      },
+      "add_more_load_shedding_plugs": {
+        "title": "Add Another Plug?",
+        "description": "{count} plug(s) configured so far.",
+        "data": {
+          "add_another": "Add another plug"
         }
       }
     },

--- a/custom_components/marstek_venus_energy_manager/strings.json
+++ b/custom_components/marstek_venus_energy_manager/strings.json
@@ -238,7 +238,7 @@
           "load_shedding_duration_min": "Minutes of sustained overload before plugs are switched off. Default: 7 min.",
           "load_shedding_min_plug_power": "Only shed plugs currently drawing at least this much power. Default: 100 W.",
           "load_shedding_notify_enabled": "Send a notification when plugs are switched off or restored.",
-          "load_shedding_notify_target": "Optional: select a notify service (e.g. mobile app) to receive push notifications in addition to the HA dashboard notification."
+          "load_shedding_notify_target": "Enter a notify service name (e.g. notify.mobile_app_iphone) to also send push notifications. Leave empty for HA dashboard notification only."
         }
       },
       "add_load_shedding_plug": {
@@ -480,7 +480,7 @@
           "load_shedding_duration_min": "Minutes of sustained overload before plugs are switched off. Default: 7 min.",
           "load_shedding_min_plug_power": "Only shed plugs currently drawing at least this much power. Default: 100 W.",
           "load_shedding_notify_enabled": "Send a notification when plugs are switched off or restored.",
-          "load_shedding_notify_target": "Optional: select a notify service (e.g. mobile app) to receive push notifications in addition to the HA dashboard notification."
+          "load_shedding_notify_target": "Enter a notify service name (e.g. notify.mobile_app_iphone) to also send push notifications. Leave empty for HA dashboard notification only."
         }
       },
       "add_load_shedding_plug": {

--- a/custom_components/marstek_venus_energy_manager/translations/en.json
+++ b/custom_components/marstek_venus_energy_manager/translations/en.json
@@ -296,6 +296,52 @@
           "pd_min_discharge_power": "Minimum power for discharging. Below this threshold, the controller stays idle instead of discharging at low power. 0 = disabled.",
           "pd_target_grid_power": "Grid power setpoint the controller regulates to. Negative = export to grid, positive = import from grid, 0 = net zero. Range: -500 to +500 W, default: 0 W."
         }
+      },
+      "load_shedding": {
+        "title": "Load Shedding",
+        "description": "Automatically switch off high-power plugs when grid draw exceeds the peak threshold for too long. Plugs are restored when the situation clears.",
+        "data": {
+          "enable_load_shedding": "Enable load shedding"
+        },
+        "data_description": {
+          "enable_load_shedding": "When enabled, nominated smart plugs will be switched off if sustained grid draw exceeds the threshold."
+        }
+      },
+      "load_shedding_config": {
+        "title": "Load Shedding — Settings",
+        "data": {
+          "load_shedding_threshold": "Peak threshold (W)",
+          "load_shedding_duration_min": "Trigger delay (minutes)",
+          "load_shedding_min_plug_power": "Minimum plug power to shed (W)",
+          "load_shedding_notify_enabled": "Enable notifications",
+          "load_shedding_notify_target": "Notification target (optional)"
+        },
+        "data_description": {
+          "load_shedding_threshold": "Grid draw above this level triggers the countdown. Default: 2500 W.",
+          "load_shedding_duration_min": "Minutes of sustained overload before plugs are switched off. Default: 7 min.",
+          "load_shedding_min_plug_power": "Only shed plugs currently drawing at least this much power. Default: 100 W.",
+          "load_shedding_notify_enabled": "Send a notification when plugs are switched off or restored.",
+          "load_shedding_notify_target": "Optional: select a notify service (e.g. mobile app) to receive push notifications in addition to the HA dashboard notification."
+        }
+      },
+      "add_load_shedding_plug": {
+        "title": "Add Plug #{plug_num}",
+        "description": "Select the switch entity for this plug. Plugs are shed in the order they are added.",
+        "data": {
+          "switch_entity": "Switch entity",
+          "power_sensor": "Power sensor (optional)"
+        },
+        "data_description": {
+          "switch_entity": "The switch entity that controls this plug.",
+          "power_sensor": "Optional power sensor. Used to check if the plug draws enough power to be worth shedding."
+        }
+      },
+      "add_more_load_shedding_plugs": {
+        "title": "Add Another Plug?",
+        "description": "{count} plug(s) configured so far.",
+        "data": {
+          "add_another": "Add another plug"
+        }
       }
     },
     "error": {
@@ -324,7 +370,8 @@
           "weekly_full_charge": "Weekly full charge",
           "charge_delay": "Solar charge delay",
           "capacity_protection": "Capacity protection",
-          "pd_advanced": "PD controller (advanced)"
+          "pd_advanced": "PD controller (advanced)",
+          "load_shedding": "Load shedding"
         }
       },
       "sensors": {
@@ -622,6 +669,52 @@
           "pd_min_discharge_power": "Minimum power for discharging. Below this threshold, the controller stays idle instead of discharging at low power. 0 = disabled.",
           "pd_target_grid_power": "Grid power setpoint the controller regulates to. Negative = export to grid, positive = import from grid, 0 = net zero. Range: -500 to +500 W, default: 0 W."
         }
+      },
+      "load_shedding": {
+        "title": "Load Shedding",
+        "description": "Automatically switch off high-power plugs when grid draw exceeds the peak threshold for too long. Plugs are restored when the situation clears.",
+        "data": {
+          "enable_load_shedding": "Enable load shedding"
+        },
+        "data_description": {
+          "enable_load_shedding": "When enabled, nominated smart plugs will be switched off if sustained grid draw exceeds the threshold."
+        }
+      },
+      "load_shedding_config": {
+        "title": "Load Shedding — Settings",
+        "data": {
+          "load_shedding_threshold": "Peak threshold (W)",
+          "load_shedding_duration_min": "Trigger delay (minutes)",
+          "load_shedding_min_plug_power": "Minimum plug power to shed (W)",
+          "load_shedding_notify_enabled": "Enable notifications",
+          "load_shedding_notify_target": "Notification target (optional)"
+        },
+        "data_description": {
+          "load_shedding_threshold": "Grid draw above this level triggers the countdown. Default: 2500 W.",
+          "load_shedding_duration_min": "Minutes of sustained overload before plugs are switched off. Default: 7 min.",
+          "load_shedding_min_plug_power": "Only shed plugs currently drawing at least this much power. Default: 100 W.",
+          "load_shedding_notify_enabled": "Send a notification when plugs are switched off or restored.",
+          "load_shedding_notify_target": "Optional: select a notify service (e.g. mobile app) to receive push notifications in addition to the HA dashboard notification."
+        }
+      },
+      "add_load_shedding_plug": {
+        "title": "Add Plug #{plug_num}",
+        "description": "Select the switch entity for this plug. Plugs are shed in the order they are added.",
+        "data": {
+          "switch_entity": "Switch entity",
+          "power_sensor": "Power sensor (optional)"
+        },
+        "data_description": {
+          "switch_entity": "The switch entity that controls this plug.",
+          "power_sensor": "Optional power sensor. Used to check if the plug draws enough power to be worth shedding."
+        }
+      },
+      "add_more_load_shedding_plugs": {
+        "title": "Add Another Plug?",
+        "description": "{count} plug(s) configured so far.",
+        "data": {
+          "add_another": "Add another plug"
+        }
       }
     },
     "error": {
@@ -661,19 +754,41 @@
   },
   "entity": {
     "switch": {
-      "manual_mode": { "name": "Manual Mode" },
-      "predictive_charging": { "name": "Predictive Charging" },
-      "charge_delay": { "name": "Charge Delay" },
-      "capacity_protection": { "name": "Peak Shaving" },
-      "backup_function": { "name": "Backup Function" },
-      "rs485_control_mode": { "name": "RS485 Control Mode" },
-      "automation_charging_active": { "name": "External Price Charging" },
-      "excluded_device_enabled": { "name": "{device} – Enabled" },
-      "excluded_device_solar_surplus": { "name": "{device} – Solar Surplus" },
-      "time_slot": { "name": "Time Slot {slot_number}" }
+      "manual_mode": {
+        "name": "Manual Mode"
+      },
+      "predictive_charging": {
+        "name": "Predictive Charging"
+      },
+      "charge_delay": {
+        "name": "Charge Delay"
+      },
+      "capacity_protection": {
+        "name": "Peak Shaving"
+      },
+      "backup_function": {
+        "name": "Backup Function"
+      },
+      "rs485_control_mode": {
+        "name": "RS485 Control Mode"
+      },
+      "automation_charging_active": {
+        "name": "External Price Charging"
+      },
+      "excluded_device_enabled": {
+        "name": "{device} – Enabled"
+      },
+      "excluded_device_solar_surplus": {
+        "name": "{device} – Solar Surplus"
+      },
+      "time_slot": {
+        "name": "Time Slot {slot_number}"
+      }
     },
     "time": {
-      "automation_charging_end_time": { "name": "External Charging End Time" }
+      "automation_charging_end_time": {
+        "name": "External Charging End Time"
+      }
     },
     "sensor": {
       "discharge_window": {
@@ -684,9 +799,15 @@
           "active": "Active"
         }
       },
-      "active_batteries": { "name": "Active Batteries" },
-      "non_responsive_batteries": { "name": "Non-Responsive Batteries" },
-      "configuration_summary": { "name": "Configuration Summary" },
+      "active_batteries": {
+        "name": "Active Batteries"
+      },
+      "non_responsive_batteries": {
+        "name": "Non-Responsive Batteries"
+      },
+      "configuration_summary": {
+        "name": "Configuration Summary"
+      },
       "integration_status": {
         "name": "Integration Status",
         "state": {
@@ -725,49 +846,135 @@
           "charging_to_setpoint": "Charging to setpoint"
         }
       },
-      "battery_soc": { "name": "Battery SOC" },
-      "battery_total_energy": { "name": "Battery Total Energy" },
-      "battery_power": { "name": "Battery Power" },
-      "internal_temperature": { "name": "Internal Temperature" },
-      "ac_power": { "name": "AC Power" },
-      "total_charging_energy": { "name": "Total Charging Energy" },
-      "total_discharging_energy": { "name": "Total Discharging Energy" },
-      "total_daily_charging_energy": { "name": "Total Daily Charging Energy" },
-      "total_daily_discharging_energy": { "name": "Total Daily Discharging Energy" },
-      "inverter_state": { "name": "Inverter State" },
-      "battery_voltage": { "name": "Battery Voltage" },
-      "max_cell_voltage": { "name": "Max Cell Voltage" },
-      "min_cell_voltage": { "name": "Min Cell Voltage" },
-      "fault_status": { "name": "Fault Status" },
-      "alarm_status": { "name": "Alarm Status" },
-      "ac_offgrid_power": { "name": "AC Offgrid Power" },
-      "mppt1_power": { "name": "MPPT1 Power" },
-      "mppt2_power": { "name": "MPPT2 Power" },
-      "mppt3_power": { "name": "MPPT3 Power" },
-      "mppt4_power": { "name": "MPPT4 Power" },
-      "round_trip_efficiency_total": { "name": "Round-Trip Efficiency" },
-      "stored_energy": { "name": "Stored Energy" },
-      "system_soc": { "name": "System SOC" },
-      "system_charge_power": { "name": "System Charge Power" },
-      "system_discharge_power": { "name": "System Discharge Power" },
-      "system_total_energy": { "name": "System Total Energy" },
-      "system_stored_energy": { "name": "System Stored Energy" },
-      "system_daily_charging_energy": { "name": "System Daily Charging Energy" },
-      "system_daily_discharging_energy": { "name": "System Daily Discharging Energy" },
-      "system_daily_grid_at_min_soc_energy": { "name": "Grid at Min SOC" },
-      "system_alarm_status": { "name": "System Alarm Status" },
-      "device_name": { "name": "Device Name" },
-      "sn_code": { "name": "Serial Number" },
-      "software_version": { "name": "Software Version" },
-      "bms_version": { "name": "BMS Version" },
-      "ems_version": { "name": "EMS Version" },
-      "vms_version": { "name": "VMS Version" },
-      "comm_module_firmware": { "name": "Comm Module Firmware" },
-      "mac_address": { "name": "MAC Address" },
-      "wifi_signal_strength": { "name": "WiFi Signal Strength" },
-      "battery_cycle_count": { "name": "Battery Cycle Count" },
-      "battery_cycle_count_calc": { "name": "Battery Cycle Count (Calc)" },
-      "cell_delta": { "name": "Cell Delta" },
+      "battery_soc": {
+        "name": "Battery SOC"
+      },
+      "battery_total_energy": {
+        "name": "Battery Total Energy"
+      },
+      "battery_power": {
+        "name": "Battery Power"
+      },
+      "internal_temperature": {
+        "name": "Internal Temperature"
+      },
+      "ac_power": {
+        "name": "AC Power"
+      },
+      "total_charging_energy": {
+        "name": "Total Charging Energy"
+      },
+      "total_discharging_energy": {
+        "name": "Total Discharging Energy"
+      },
+      "total_daily_charging_energy": {
+        "name": "Total Daily Charging Energy"
+      },
+      "total_daily_discharging_energy": {
+        "name": "Total Daily Discharging Energy"
+      },
+      "inverter_state": {
+        "name": "Inverter State"
+      },
+      "battery_voltage": {
+        "name": "Battery Voltage"
+      },
+      "max_cell_voltage": {
+        "name": "Max Cell Voltage"
+      },
+      "min_cell_voltage": {
+        "name": "Min Cell Voltage"
+      },
+      "fault_status": {
+        "name": "Fault Status"
+      },
+      "alarm_status": {
+        "name": "Alarm Status"
+      },
+      "ac_offgrid_power": {
+        "name": "AC Offgrid Power"
+      },
+      "mppt1_power": {
+        "name": "MPPT1 Power"
+      },
+      "mppt2_power": {
+        "name": "MPPT2 Power"
+      },
+      "mppt3_power": {
+        "name": "MPPT3 Power"
+      },
+      "mppt4_power": {
+        "name": "MPPT4 Power"
+      },
+      "round_trip_efficiency_total": {
+        "name": "Round-Trip Efficiency"
+      },
+      "stored_energy": {
+        "name": "Stored Energy"
+      },
+      "system_soc": {
+        "name": "System SOC"
+      },
+      "system_charge_power": {
+        "name": "System Charge Power"
+      },
+      "system_discharge_power": {
+        "name": "System Discharge Power"
+      },
+      "system_total_energy": {
+        "name": "System Total Energy"
+      },
+      "system_stored_energy": {
+        "name": "System Stored Energy"
+      },
+      "system_daily_charging_energy": {
+        "name": "System Daily Charging Energy"
+      },
+      "system_daily_discharging_energy": {
+        "name": "System Daily Discharging Energy"
+      },
+      "system_daily_grid_at_min_soc_energy": {
+        "name": "Grid at Min SOC"
+      },
+      "system_alarm_status": {
+        "name": "System Alarm Status"
+      },
+      "device_name": {
+        "name": "Device Name"
+      },
+      "sn_code": {
+        "name": "Serial Number"
+      },
+      "software_version": {
+        "name": "Software Version"
+      },
+      "bms_version": {
+        "name": "BMS Version"
+      },
+      "ems_version": {
+        "name": "EMS Version"
+      },
+      "vms_version": {
+        "name": "VMS Version"
+      },
+      "comm_module_firmware": {
+        "name": "Comm Module Firmware"
+      },
+      "mac_address": {
+        "name": "MAC Address"
+      },
+      "wifi_signal_strength": {
+        "name": "WiFi Signal Strength"
+      },
+      "battery_cycle_count": {
+        "name": "Battery Cycle Count"
+      },
+      "battery_cycle_count_calc": {
+        "name": "Battery Cycle Count (Calc)"
+      },
+      "cell_delta": {
+        "name": "Cell Delta"
+      },
       "balance_status": {
         "name": "Balance Status",
         "state": {
@@ -787,18 +994,34 @@
           "unknown": "Unknown"
         }
       },
-      "last_balance_read": { "name": "Last Balance Reading" },
-      "delta_avg_4w": { "name": "Delta Average (4 readings)" }
+      "last_balance_read": {
+        "name": "Last Balance Reading"
+      },
+      "delta_avg_4w": {
+        "name": "Delta Average (4 readings)"
+      }
     },
     "binary_sensor": {
-      "capacity_protection_active": { "name": "Peak Shaving Active" },
-      "predictive_charging_active": { "name": "Predictive Charging Active" },
-      "wifi_status": { "name": "WiFi Status" },
-      "cloud_status": { "name": "Cloud Status" },
-      "charge_hysteresis": { "name": "Charge Hysteresis" }
+      "capacity_protection_active": {
+        "name": "Peak Shaving Active"
+      },
+      "predictive_charging_active": {
+        "name": "Predictive Charging Active"
+      },
+      "wifi_status": {
+        "name": "WiFi Status"
+      },
+      "cloud_status": {
+        "name": "Cloud Status"
+      },
+      "charge_hysteresis": {
+        "name": "Charge Hysteresis"
+      }
     },
     "select": {
-      "force_mode": { "name": "Force Mode" },
+      "force_mode": {
+        "name": "Force Mode"
+      },
       "user_work_mode": {
         "name": "User Work Mode",
         "state": {
@@ -821,32 +1044,80 @@
       }
     },
     "number": {
-      "set_charge_power": { "name": "Set Charge Power" },
-      "set_discharge_power": { "name": "Set Discharge Power" },
-      "max_charge_power": { "name": "Max Charge Power" },
-      "max_discharge_power": { "name": "Max Discharge Power" },
-      "charging_cutoff_capacity": { "name": "Charging Cutoff Capacity" },
-      "discharging_cutoff_capacity": { "name": "Discharging Cutoff Capacity" },
-      "charge_to_soc": { "name": "Charge To SOC" },
-      "pd_controller_kp": { "name": "PD Kp" },
-      "pd_controller_kd": { "name": "PD Kd" },
-      "pd_controller_deadband": { "name": "PD Deadband" },
-      "pd_controller_max_power_change": { "name": "PD Max Power Change" },
-      "pd_controller_direction_hysteresis": { "name": "PD Direction Hysteresis" },
-      "pd_min_charge_power": { "name": "PD Min Charge Power" },
-      "pd_min_discharge_power": { "name": "PD Min Discharge Power" },
-      "pd_target_grid_power": { "name": "PD Target Grid Power" },
-      "max_contracted_power": { "name": "Max Contracted Power" },
-      "capacity_protection_soc_threshold": { "name": "Peak Shaving SOC Threshold" },
-      "delay_safety_margin_min": { "name": "Charge Delay Margin" },
-      "delay_soc_setpoint": { "name": "Charge Delay SOC Setpoint" },
-      "capacity_protection_limit": { "name": "Peak Shaving Limit" },
-      "backup_offgrid_threshold": { "name": "Backup Offgrid Threshold" },
-      "charge_hysteresis_percent": { "name": "Charge Hysteresis Percent" },
-      "predictive_safety_margin_kwh": { "name": "Solar Forecast Safety Margin" }
+      "set_charge_power": {
+        "name": "Set Charge Power"
+      },
+      "set_discharge_power": {
+        "name": "Set Discharge Power"
+      },
+      "max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "charging_cutoff_capacity": {
+        "name": "Charging Cutoff Capacity"
+      },
+      "discharging_cutoff_capacity": {
+        "name": "Discharging Cutoff Capacity"
+      },
+      "charge_to_soc": {
+        "name": "Charge To SOC"
+      },
+      "pd_controller_kp": {
+        "name": "PD Kp"
+      },
+      "pd_controller_kd": {
+        "name": "PD Kd"
+      },
+      "pd_controller_deadband": {
+        "name": "PD Deadband"
+      },
+      "pd_controller_max_power_change": {
+        "name": "PD Max Power Change"
+      },
+      "pd_controller_direction_hysteresis": {
+        "name": "PD Direction Hysteresis"
+      },
+      "pd_min_charge_power": {
+        "name": "PD Min Charge Power"
+      },
+      "pd_min_discharge_power": {
+        "name": "PD Min Discharge Power"
+      },
+      "pd_target_grid_power": {
+        "name": "PD Target Grid Power"
+      },
+      "max_contracted_power": {
+        "name": "Max Contracted Power"
+      },
+      "capacity_protection_soc_threshold": {
+        "name": "Peak Shaving SOC Threshold"
+      },
+      "delay_safety_margin_min": {
+        "name": "Charge Delay Margin"
+      },
+      "delay_soc_setpoint": {
+        "name": "Charge Delay SOC Setpoint"
+      },
+      "capacity_protection_limit": {
+        "name": "Peak Shaving Limit"
+      },
+      "backup_offgrid_threshold": {
+        "name": "Backup Offgrid Threshold"
+      },
+      "charge_hysteresis_percent": {
+        "name": "Charge Hysteresis Percent"
+      },
+      "predictive_safety_margin_kwh": {
+        "name": "Solar Forecast Safety Margin"
+      }
     },
     "button": {
-      "reset_device": { "name": "Reset Device" }
+      "reset_device": {
+        "name": "Reset Device"
+      }
     }
   }
 }

--- a/custom_components/marstek_venus_energy_manager/translations/en.json
+++ b/custom_components/marstek_venus_energy_manager/translations/en.json
@@ -321,7 +321,7 @@
           "load_shedding_duration_min": "Minutes of sustained overload before plugs are switched off. Default: 7 min.",
           "load_shedding_min_plug_power": "Only shed plugs currently drawing at least this much power. Default: 100 W.",
           "load_shedding_notify_enabled": "Send a notification when plugs are switched off or restored.",
-          "load_shedding_notify_target": "Optional: select a notify service (e.g. mobile app) to receive push notifications in addition to the HA dashboard notification."
+          "load_shedding_notify_target": "Enter a notify service name (e.g. notify.mobile_app_iphone) to also send push notifications. Leave empty for HA dashboard notification only."
         }
       },
       "add_load_shedding_plug": {
@@ -694,7 +694,7 @@
           "load_shedding_duration_min": "Minutes of sustained overload before plugs are switched off. Default: 7 min.",
           "load_shedding_min_plug_power": "Only shed plugs currently drawing at least this much power. Default: 100 W.",
           "load_shedding_notify_enabled": "Send a notification when plugs are switched off or restored.",
-          "load_shedding_notify_target": "Optional: select a notify service (e.g. mobile app) to receive push notifications in addition to the HA dashboard notification."
+          "load_shedding_notify_target": "Enter a notify service name (e.g. notify.mobile_app_iphone) to also send push notifications. Leave empty for HA dashboard notification only."
         }
       },
       "add_load_shedding_plug": {

--- a/custom_components/marstek_venus_energy_manager/translations/nl.json
+++ b/custom_components/marstek_venus_energy_manager/translations/nl.json
@@ -296,6 +296,52 @@
           "pd_min_discharge_power": "Minimaal vermogen om te ontladen. Onder deze drempel blijft de regelaar inactief in plaats van ontladen op laag vermogen. 0 = uitgeschakeld.",
           "pd_target_grid_power": "Netvermogen-setpoint waarop de regelaar regelt. Negatief = teruglevering, positief = afname, 0 = netto nul. Bereik: -500 tot +500 W, standaard: 0 W."
         }
+      },
+      "load_shedding": {
+        "title": "Belastingafschakeling",
+        "description": "Schakel automatisch krachtige stekkers uit wanneer het netvermogen de piekdrempel te lang overschrijdt. Stekkers worden hersteld zodra de situatie normaliseert.",
+        "data": {
+          "enable_load_shedding": "Belastingafschakeling inschakelen"
+        },
+        "data_description": {
+          "enable_load_shedding": "Wanneer ingeschakeld, worden genomineerde stekkers uitgeschakeld als het netvermogen de drempel aanhoudend overschrijdt."
+        }
+      },
+      "load_shedding_config": {
+        "title": "Belastingafschakeling — Instellingen",
+        "data": {
+          "load_shedding_threshold": "Piekdrempel (W)",
+          "load_shedding_duration_min": "Activeringsvertraging (minuten)",
+          "load_shedding_min_plug_power": "Minimaal verbruik om af te schakelen (W)",
+          "load_shedding_notify_enabled": "Meldingen inschakelen",
+          "load_shedding_notify_target": "Meldingsdoel (optioneel)"
+        },
+        "data_description": {
+          "load_shedding_threshold": "Netvermogen boven dit niveau start de aftelling. Standaard: 2500 W.",
+          "load_shedding_duration_min": "Minuten aanhoudende overbelasting voordat stekkers worden uitgeschakeld. Standaard: 7 min.",
+          "load_shedding_min_plug_power": "Schakel alleen stekkers af die momenteel minstens dit vermogen verbruiken. Standaard: 100 W.",
+          "load_shedding_notify_enabled": "Stuur een melding wanneer stekkers worden uitgeschakeld of hersteld.",
+          "load_shedding_notify_target": "Optioneel: selecteer een meldingsservice (bijv. mobiele app) voor pushmeldingen naast de HA-dashboardmelding."
+        }
+      },
+      "add_load_shedding_plug": {
+        "title": "Stekker #{plug_num} toevoegen",
+        "description": "Selecteer de schakelaar-entiteit voor deze stekker. Stekkers worden afgeschakeld in de volgorde van toevoeging.",
+        "data": {
+          "switch_entity": "Schakelaar-entiteit",
+          "power_sensor": "Vermogenssensor (optioneel)"
+        },
+        "data_description": {
+          "switch_entity": "De schakelaar-entiteit die deze stekker bestuurt.",
+          "power_sensor": "Optionele vermogenssensor. Wordt gebruikt om te controleren of de stekker genoeg verbruikt om af te schakelen."
+        }
+      },
+      "add_more_load_shedding_plugs": {
+        "title": "Nog een stekker toevoegen?",
+        "description": "{count} stekker(s) geconfigureerd.",
+        "data": {
+          "add_another": "Nog een stekker toevoegen"
+        }
       }
     },
     "error": {
@@ -324,7 +370,8 @@
           "weekly_full_charge": "Wekelijkse volledige lading",
           "charge_delay": "Zonne-oplaadvertraging",
           "capacity_protection": "Capaciteitsbescherming",
-          "pd_advanced": "PD-regelaar (geavanceerd)"
+          "pd_advanced": "PD-regelaar (geavanceerd)",
+          "load_shedding": "Belastingafschakeling"
         }
       },
       "sensors": {
@@ -622,6 +669,52 @@
           "pd_min_discharge_power": "Minimaal vermogen om te ontladen. Onder deze drempel blijft de regelaar inactief in plaats van ontladen op laag vermogen. 0 = uitgeschakeld.",
           "pd_target_grid_power": "Netvermogen-setpoint waarop de regelaar regelt. Negatief = teruglevering, positief = afname, 0 = netto nul. Bereik: -500 tot +500 W, standaard: 0 W."
         }
+      },
+      "load_shedding": {
+        "title": "Belastingafschakeling",
+        "description": "Schakel automatisch krachtige stekkers uit wanneer het netvermogen de piekdrempel te lang overschrijdt. Stekkers worden hersteld zodra de situatie normaliseert.",
+        "data": {
+          "enable_load_shedding": "Belastingafschakeling inschakelen"
+        },
+        "data_description": {
+          "enable_load_shedding": "Wanneer ingeschakeld, worden genomineerde stekkers uitgeschakeld als het netvermogen de drempel aanhoudend overschrijdt."
+        }
+      },
+      "load_shedding_config": {
+        "title": "Belastingafschakeling — Instellingen",
+        "data": {
+          "load_shedding_threshold": "Piekdrempel (W)",
+          "load_shedding_duration_min": "Activeringsvertraging (minuten)",
+          "load_shedding_min_plug_power": "Minimaal verbruik om af te schakelen (W)",
+          "load_shedding_notify_enabled": "Meldingen inschakelen",
+          "load_shedding_notify_target": "Meldingsdoel (optioneel)"
+        },
+        "data_description": {
+          "load_shedding_threshold": "Netvermogen boven dit niveau start de aftelling. Standaard: 2500 W.",
+          "load_shedding_duration_min": "Minuten aanhoudende overbelasting voordat stekkers worden uitgeschakeld. Standaard: 7 min.",
+          "load_shedding_min_plug_power": "Schakel alleen stekkers af die momenteel minstens dit vermogen verbruiken. Standaard: 100 W.",
+          "load_shedding_notify_enabled": "Stuur een melding wanneer stekkers worden uitgeschakeld of hersteld.",
+          "load_shedding_notify_target": "Optioneel: selecteer een meldingsservice (bijv. mobiele app) voor pushmeldingen naast de HA-dashboardmelding."
+        }
+      },
+      "add_load_shedding_plug": {
+        "title": "Stekker #{plug_num} toevoegen",
+        "description": "Selecteer de schakelaar-entiteit voor deze stekker. Stekkers worden afgeschakeld in de volgorde van toevoeging.",
+        "data": {
+          "switch_entity": "Schakelaar-entiteit",
+          "power_sensor": "Vermogenssensor (optioneel)"
+        },
+        "data_description": {
+          "switch_entity": "De schakelaar-entiteit die deze stekker bestuurt.",
+          "power_sensor": "Optionele vermogenssensor. Wordt gebruikt om te controleren of de stekker genoeg verbruikt om af te schakelen."
+        }
+      },
+      "add_more_load_shedding_plugs": {
+        "title": "Nog een stekker toevoegen?",
+        "description": "{count} stekker(s) geconfigureerd.",
+        "data": {
+          "add_another": "Nog een stekker toevoegen"
+        }
       }
     },
     "error": {
@@ -662,19 +755,41 @@
   },
   "entity": {
     "switch": {
-      "manual_mode": { "name": "Handmatige Modus" },
-      "predictive_charging": { "name": "Voorspellend Laden" },
-      "charge_delay": { "name": "Laadvertraging" },
-      "capacity_protection": { "name": "Piekbegrenzing" },
-      "backup_function": { "name": "Back-upfunctie" },
-      "rs485_control_mode": { "name": "RS485-besturingsmodus" },
-      "automation_charging_active": { "name": "Laden op Externe Prijs" },
-      "excluded_device_enabled": { "name": "{device} – Actief" },
-      "excluded_device_solar_surplus": { "name": "{device} – Zonne-overschot" },
-      "time_slot": { "name": "Tijdslot {slot_number}" }
+      "manual_mode": {
+        "name": "Handmatige Modus"
+      },
+      "predictive_charging": {
+        "name": "Voorspellend Laden"
+      },
+      "charge_delay": {
+        "name": "Laadvertraging"
+      },
+      "capacity_protection": {
+        "name": "Piekbegrenzing"
+      },
+      "backup_function": {
+        "name": "Back-upfunctie"
+      },
+      "rs485_control_mode": {
+        "name": "RS485-besturingsmodus"
+      },
+      "automation_charging_active": {
+        "name": "Laden op Externe Prijs"
+      },
+      "excluded_device_enabled": {
+        "name": "{device} – Actief"
+      },
+      "excluded_device_solar_surplus": {
+        "name": "{device} – Zonne-overschot"
+      },
+      "time_slot": {
+        "name": "Tijdslot {slot_number}"
+      }
     },
     "time": {
-      "automation_charging_end_time": { "name": "Einde Extern Laden" }
+      "automation_charging_end_time": {
+        "name": "Einde Extern Laden"
+      }
     },
     "sensor": {
       "discharge_window": {
@@ -685,9 +800,15 @@
           "active": "Actief"
         }
       },
-      "active_batteries": { "name": "Actieve Batterijen" },
-      "non_responsive_batteries": { "name": "Niet-reagerende Batterijen" },
-      "configuration_summary": { "name": "Configuratieoverzicht" },
+      "active_batteries": {
+        "name": "Actieve Batterijen"
+      },
+      "non_responsive_batteries": {
+        "name": "Niet-reagerende Batterijen"
+      },
+      "configuration_summary": {
+        "name": "Configuratieoverzicht"
+      },
       "integration_status": {
         "name": "Integratiestatus",
         "state": {
@@ -726,49 +847,135 @@
           "charging_to_setpoint": "Laden tot setpoint"
         }
       },
-      "battery_soc": { "name": "Batterij SOC" },
-      "battery_total_energy": { "name": "Totale Batterijenergie" },
-      "battery_power": { "name": "Batterijvermogen" },
-      "internal_temperature": { "name": "Interne Temperatuur" },
-      "ac_power": { "name": "AC-Vermogen" },
-      "total_charging_energy": { "name": "Totale Laadenergie" },
-      "total_discharging_energy": { "name": "Totale Ontlaadenergie" },
-      "total_daily_charging_energy": { "name": "Dagelijkse Laadenergie" },
-      "total_daily_discharging_energy": { "name": "Dagelijkse Ontlaadenergie" },
-      "inverter_state": { "name": "Omvormerstatus" },
-      "battery_voltage": { "name": "Batterijspanning" },
-      "max_cell_voltage": { "name": "Maximale Celspanning" },
-      "min_cell_voltage": { "name": "Minimale Celspanning" },
-      "fault_status": { "name": "Foutstatus" },
-      "alarm_status": { "name": "Alarmstatus" },
-      "ac_offgrid_power": { "name": "AC Off-grid Vermogen" },
-      "mppt1_power": { "name": "MPPT1-Vermogen" },
-      "mppt2_power": { "name": "MPPT2-Vermogen" },
-      "mppt3_power": { "name": "MPPT3-Vermogen" },
-      "mppt4_power": { "name": "MPPT4-Vermogen" },
-      "round_trip_efficiency_total": { "name": "Totaal Rendement" },
-      "stored_energy": { "name": "Opgeslagen Energie" },
-      "system_soc": { "name": "Systeem SOC" },
-      "system_charge_power": { "name": "Systeem Laadvermogen" },
-      "system_discharge_power": { "name": "Systeem Ontlaadvermogen" },
-      "system_total_energy": { "name": "Systeem Totale Energie" },
-      "system_stored_energy": { "name": "Systeem Opgeslagen Energie" },
-      "system_daily_charging_energy": { "name": "Dagelijkse Systeem Laadenergie" },
-      "system_daily_discharging_energy": { "name": "Dagelijkse Systeem Ontlaadenergie" },
-      "system_daily_grid_at_min_soc_energy": { "name": "Net bij Min. SOC" },
-      "system_alarm_status": { "name": "Systeem Alarmstatus" },
-      "device_name": { "name": "Apparaatnaam" },
-      "sn_code": { "name": "Serienummer" },
-      "software_version": { "name": "Softwareversie" },
-      "bms_version": { "name": "BMS-versie" },
-      "ems_version": { "name": "EMS-versie" },
-      "vms_version": { "name": "VMS-versie" },
-      "comm_module_firmware": { "name": "Firmware Communicatiemodule" },
-      "mac_address": { "name": "MAC-adres" },
-      "wifi_signal_strength": { "name": "WiFi-signaalsterkte" },
-      "battery_cycle_count": { "name": "Batterijcycli" },
-      "battery_cycle_count_calc": { "name": "Batterijcycli (Berekend)" },
-      "cell_delta": { "name": "Celdelta" },
+      "battery_soc": {
+        "name": "Batterij SOC"
+      },
+      "battery_total_energy": {
+        "name": "Totale Batterijenergie"
+      },
+      "battery_power": {
+        "name": "Batterijvermogen"
+      },
+      "internal_temperature": {
+        "name": "Interne Temperatuur"
+      },
+      "ac_power": {
+        "name": "AC-Vermogen"
+      },
+      "total_charging_energy": {
+        "name": "Totale Laadenergie"
+      },
+      "total_discharging_energy": {
+        "name": "Totale Ontlaadenergie"
+      },
+      "total_daily_charging_energy": {
+        "name": "Dagelijkse Laadenergie"
+      },
+      "total_daily_discharging_energy": {
+        "name": "Dagelijkse Ontlaadenergie"
+      },
+      "inverter_state": {
+        "name": "Omvormerstatus"
+      },
+      "battery_voltage": {
+        "name": "Batterijspanning"
+      },
+      "max_cell_voltage": {
+        "name": "Maximale Celspanning"
+      },
+      "min_cell_voltage": {
+        "name": "Minimale Celspanning"
+      },
+      "fault_status": {
+        "name": "Foutstatus"
+      },
+      "alarm_status": {
+        "name": "Alarmstatus"
+      },
+      "ac_offgrid_power": {
+        "name": "AC Off-grid Vermogen"
+      },
+      "mppt1_power": {
+        "name": "MPPT1-Vermogen"
+      },
+      "mppt2_power": {
+        "name": "MPPT2-Vermogen"
+      },
+      "mppt3_power": {
+        "name": "MPPT3-Vermogen"
+      },
+      "mppt4_power": {
+        "name": "MPPT4-Vermogen"
+      },
+      "round_trip_efficiency_total": {
+        "name": "Totaal Rendement"
+      },
+      "stored_energy": {
+        "name": "Opgeslagen Energie"
+      },
+      "system_soc": {
+        "name": "Systeem SOC"
+      },
+      "system_charge_power": {
+        "name": "Systeem Laadvermogen"
+      },
+      "system_discharge_power": {
+        "name": "Systeem Ontlaadvermogen"
+      },
+      "system_total_energy": {
+        "name": "Systeem Totale Energie"
+      },
+      "system_stored_energy": {
+        "name": "Systeem Opgeslagen Energie"
+      },
+      "system_daily_charging_energy": {
+        "name": "Dagelijkse Systeem Laadenergie"
+      },
+      "system_daily_discharging_energy": {
+        "name": "Dagelijkse Systeem Ontlaadenergie"
+      },
+      "system_daily_grid_at_min_soc_energy": {
+        "name": "Net bij Min. SOC"
+      },
+      "system_alarm_status": {
+        "name": "Systeem Alarmstatus"
+      },
+      "device_name": {
+        "name": "Apparaatnaam"
+      },
+      "sn_code": {
+        "name": "Serienummer"
+      },
+      "software_version": {
+        "name": "Softwareversie"
+      },
+      "bms_version": {
+        "name": "BMS-versie"
+      },
+      "ems_version": {
+        "name": "EMS-versie"
+      },
+      "vms_version": {
+        "name": "VMS-versie"
+      },
+      "comm_module_firmware": {
+        "name": "Firmware Communicatiemodule"
+      },
+      "mac_address": {
+        "name": "MAC-adres"
+      },
+      "wifi_signal_strength": {
+        "name": "WiFi-signaalsterkte"
+      },
+      "battery_cycle_count": {
+        "name": "Batterijcycli"
+      },
+      "battery_cycle_count_calc": {
+        "name": "Batterijcycli (Berekend)"
+      },
+      "cell_delta": {
+        "name": "Celdelta"
+      },
       "balance_status": {
         "name": "Balansstatus",
         "state": {
@@ -788,18 +995,34 @@
           "unknown": "Onbekend"
         }
       },
-      "last_balance_read": { "name": "Laatste Balansmeting" },
-      "delta_avg_4w": { "name": "Delta Gemiddelde (4 metingen)" }
+      "last_balance_read": {
+        "name": "Laatste Balansmeting"
+      },
+      "delta_avg_4w": {
+        "name": "Delta Gemiddelde (4 metingen)"
+      }
     },
     "binary_sensor": {
-      "capacity_protection_active": { "name": "Piekbegrenzing Actief" },
-      "predictive_charging_active": { "name": "Voorspellend Laden Actief" },
-      "wifi_status": { "name": "WiFi-status" },
-      "cloud_status": { "name": "Cloudstatus" },
-      "charge_hysteresis": { "name": "Laadhysterese" }
+      "capacity_protection_active": {
+        "name": "Piekbegrenzing Actief"
+      },
+      "predictive_charging_active": {
+        "name": "Voorspellend Laden Actief"
+      },
+      "wifi_status": {
+        "name": "WiFi-status"
+      },
+      "cloud_status": {
+        "name": "Cloudstatus"
+      },
+      "charge_hysteresis": {
+        "name": "Laadhysterese"
+      }
     },
     "select": {
-      "force_mode": { "name": "Geforceerde Modus" },
+      "force_mode": {
+        "name": "Geforceerde Modus"
+      },
       "user_work_mode": {
         "name": "Werkmodus",
         "state": {
@@ -822,32 +1045,80 @@
       }
     },
     "number": {
-      "set_charge_power": { "name": "Laadvermogen" },
-      "set_discharge_power": { "name": "Ontlaadvermogen" },
-      "max_charge_power": { "name": "Max. Laadvermogen" },
-      "max_discharge_power": { "name": "Max. Ontlaadvermogen" },
-      "charging_cutoff_capacity": { "name": "SOC Laadgrens" },
-      "discharging_cutoff_capacity": { "name": "SOC Ontlaadgrens" },
-      "charge_to_soc": { "name": "Laden tot SOC" },
-      "pd_controller_kp": { "name": "PD Kp" },
-      "pd_controller_kd": { "name": "PD Kd" },
-      "pd_controller_deadband": { "name": "PD Dode Zone" },
-      "pd_controller_max_power_change": { "name": "PD Max. Vermogenswijziging" },
-      "pd_controller_direction_hysteresis": { "name": "PD Richtingshysterese" },
-      "pd_min_charge_power": { "name": "PD Min. Laadvermogen" },
-      "pd_min_discharge_power": { "name": "PD Min. Ontlaadvermogen" },
-      "pd_target_grid_power": { "name": "PD Doelnetvermogen" },
-      "max_contracted_power": { "name": "Max. Gecontracteerd Vermogen" },
-      "capacity_protection_soc_threshold": { "name": "Piekbegrenzing – SOC Drempel" },
-      "delay_safety_margin_min": { "name": "Laadvertraging – Marge" },
-      "delay_soc_setpoint": { "name": "Laadvertraging – SOC-drempel" },
-      "capacity_protection_limit": { "name": "Piekbegrenzing Limiet" },
-      "backup_offgrid_threshold": { "name": "Backup Offgrid Drempel" },
-      "charge_hysteresis_percent": { "name": "Laadhysterese Percentage" },
-      "predictive_safety_margin_kwh": { "name": "Veiligheidsmarge Zonneprognose" }
+      "set_charge_power": {
+        "name": "Laadvermogen"
+      },
+      "set_discharge_power": {
+        "name": "Ontlaadvermogen"
+      },
+      "max_charge_power": {
+        "name": "Max. Laadvermogen"
+      },
+      "max_discharge_power": {
+        "name": "Max. Ontlaadvermogen"
+      },
+      "charging_cutoff_capacity": {
+        "name": "SOC Laadgrens"
+      },
+      "discharging_cutoff_capacity": {
+        "name": "SOC Ontlaadgrens"
+      },
+      "charge_to_soc": {
+        "name": "Laden tot SOC"
+      },
+      "pd_controller_kp": {
+        "name": "PD Kp"
+      },
+      "pd_controller_kd": {
+        "name": "PD Kd"
+      },
+      "pd_controller_deadband": {
+        "name": "PD Dode Zone"
+      },
+      "pd_controller_max_power_change": {
+        "name": "PD Max. Vermogenswijziging"
+      },
+      "pd_controller_direction_hysteresis": {
+        "name": "PD Richtingshysterese"
+      },
+      "pd_min_charge_power": {
+        "name": "PD Min. Laadvermogen"
+      },
+      "pd_min_discharge_power": {
+        "name": "PD Min. Ontlaadvermogen"
+      },
+      "pd_target_grid_power": {
+        "name": "PD Doelnetvermogen"
+      },
+      "max_contracted_power": {
+        "name": "Max. Gecontracteerd Vermogen"
+      },
+      "capacity_protection_soc_threshold": {
+        "name": "Piekbegrenzing – SOC Drempel"
+      },
+      "delay_safety_margin_min": {
+        "name": "Laadvertraging – Marge"
+      },
+      "delay_soc_setpoint": {
+        "name": "Laadvertraging – SOC-drempel"
+      },
+      "capacity_protection_limit": {
+        "name": "Piekbegrenzing Limiet"
+      },
+      "backup_offgrid_threshold": {
+        "name": "Backup Offgrid Drempel"
+      },
+      "charge_hysteresis_percent": {
+        "name": "Laadhysterese Percentage"
+      },
+      "predictive_safety_margin_kwh": {
+        "name": "Veiligheidsmarge Zonneprognose"
+      }
     },
     "button": {
-      "reset_device": { "name": "Apparaat Resetten" }
+      "reset_device": {
+        "name": "Apparaat Resetten"
+      }
     }
   }
 }

--- a/custom_components/marstek_venus_energy_manager/translations/nl.json
+++ b/custom_components/marstek_venus_energy_manager/translations/nl.json
@@ -321,7 +321,7 @@
           "load_shedding_duration_min": "Minuten aanhoudende overbelasting voordat stekkers worden uitgeschakeld. Standaard: 7 min.",
           "load_shedding_min_plug_power": "Schakel alleen stekkers af die momenteel minstens dit vermogen verbruiken. Standaard: 100 W.",
           "load_shedding_notify_enabled": "Stuur een melding wanneer stekkers worden uitgeschakeld of hersteld.",
-          "load_shedding_notify_target": "Optioneel: selecteer een meldingsservice (bijv. mobiele app) voor pushmeldingen naast de HA-dashboardmelding."
+          "load_shedding_notify_target": "Voer een meldingsservicenaam in (bijv. notify.mobile_app_iphone) voor pushmeldingen. Laat leeg voor alleen de HA-dashboardmelding."
         }
       },
       "add_load_shedding_plug": {
@@ -694,7 +694,7 @@
           "load_shedding_duration_min": "Minuten aanhoudende overbelasting voordat stekkers worden uitgeschakeld. Standaard: 7 min.",
           "load_shedding_min_plug_power": "Schakel alleen stekkers af die momenteel minstens dit vermogen verbruiken. Standaard: 100 W.",
           "load_shedding_notify_enabled": "Stuur een melding wanneer stekkers worden uitgeschakeld of hersteld.",
-          "load_shedding_notify_target": "Optioneel: selecteer een meldingsservice (bijv. mobiele app) voor pushmeldingen naast de HA-dashboardmelding."
+          "load_shedding_notify_target": "Voer een meldingsservicenaam in (bijv. notify.mobile_app_iphone) voor pushmeldingen. Laat leeg voor alleen de HA-dashboardmelding."
         }
       },
       "add_load_shedding_plug": {


### PR DESCRIPTION
## Summary

- Adds a **Load Shedding** feature to the Options Flow that switches off nominated smart plugs when sustained grid draw exceeds a configurable threshold for too long, then restores them automatically when the situation resolves.
- Fully configurable via the HA GUI — no YAML required.
- Notifications sent via HA persistent notification (always) and an optional push notification target (ServiceSelector for any `notify.*` service).

## Motivation

Belgian [capaciteitstarief](https://www.fluvius.be/nl/thema/nettarieven/capaciteitstarief) charges extra for the highest 15-minute average power draw above 2500 W per month. Large appliances (washing machine + tumble dryer running simultaneously) can spike the monthly peak significantly if the batteries happen to be empty at the time. This feature catches that before the 15-minute window closes.

## New behaviour

When **Load Shedding** is enabled:

1. The `LoadSheddingManager` runs every 2 s alongside the PD controller.
2. If `grid_power > threshold` continuously for `> trigger_delay` minutes:
   - Plugs are iterated in configured order.
   - Each plug drawing ≥ `min_plug_power` W is switched off until the estimated excess is covered.
   - A notification is sent (HA dashboard + optional push target).
3. When `grid_power` drops back below the threshold, all shed plugs are restored and another notification is sent.

## Configuration (Options Flow → Load Shedding)

| Field | Default | Description |
|---|---|---|
| Peak threshold | 2500 W | Grid draw level that starts the countdown |
| Trigger delay | 7 min | How long the overload must persist |
| Min plug power | 100 W | Skip plugs consuming less than this |
| Enable notifications | ✓ | HA persistent notification on shed/restore |
| Notification target | (none) | Optional `notify.*` service for push notifications |
| Plugs (ordered list) | — | Switch entity + optional power sensor per plug |

## Files changed

- **new** `load_shed_manager.py` — `LoadSheddingManager` class (pattern: `alarm_notifier.py`)
- `const.py` — 7 new `CONF_LOAD_SHEDDING_*` and 4 `DEFAULT_LOAD_SHEDDING_*` constants
- `__init__.py` — controller attribute, update-loop call, `async_setup_entry` wiring
- `config_flow.py` — 4 wizard steps in both `MarstekVenusConfigFlow` and `OptionsFlowHandler`, `ServiceSelector` import, new menu entry
- `strings.json` / `translations/en.json` / `translations/nl.json` — step strings and descriptions

## Test plan

- [ ] Initial config flow completes without errors; `load_shedding_enabled=False` saved by default when skipped
- [ ] Options Flow → Load Shedding → enable, add two plugs → confirm config saved
- [ ] With threshold set lower than current grid draw: confirm plugs switch off after delay, notification appears
- [ ] Grid drops below threshold: confirm plugs restored, restore notification appears
- [ ] Edge case: both plugs < min_plug_power → no shedding, warning logged
- [ ] Edge case: first plug alone covers excess → second plug NOT switched off

🤖 Generated with [Claude Code](https://claude.com/claude-code)