### PR TITLE
chore: add pytest test suite and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install test dependencies
+        run: pip install -r requirements-test.txt
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ Thumbs.db
 desktop.ini
 
 # Testing and coverage
+.venv-test/
 .pytest_cache/
 .coverage
 .coverage.*
@@ -53,3 +54,4 @@ site-docs/features/cell-balance-monitor.es.md
 graphify-out/
 design_handoff_mvem_dashboard/
 MULTI_BATTERY_MIGRATION_PLAN.md
+ROADMAP.md

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto
+
+# The Home Assistant pytest plugin registers autouse fixtures that build a full
+# HA event loop for every test. On Windows that loop needs a local socketpair
+# which pytest-socket (bundled with the plugin) blocks, so the plugin makes the
+# whole suite error at setup. These unit tests use none of the plugin's fixtures
+# (no `hass`), so disabling it gives a fast run that is green on Windows and Linux.
+# Future integration tests that need the `hass` fixture should re-enable the plugin
+# (drop this flag) and run on Linux/CI.
+addopts = -p no:homeassistant

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,13 @@
+# Test dependencies. Install into a Python 3.12/3.13 venv:
+#   py -3.12 -m venv .venv-test
+#   .venv-test\Scripts\python -m pip install -r requirements-test.txt
+#   .venv-test\Scripts\python -m pytest
+#
+# pytest-homeassistant-custom-component pins a compatible homeassistant,
+# pytest, and pytest-asyncio, so the Home Assistant core is mocked in-process
+# and no real battery or Modbus connection is needed.
+pytest-homeassistant-custom-component
+
+# Runtime requirement from manifest.json. The integration's package __init__
+# imports pymodbus at module load, so it must be present to import any submodule.
+pymodbus>=3.5.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Shared pytest configuration for the Marstek Venus Energy Manager test suite.
+
+The Home Assistant test harness comes from ``pytest-homeassistant-custom-component``.
+Nothing here talks to real hardware.
+
+Note: tests that use the full in-process ``hass`` fixture build a Home Assistant
+event loop. On Windows that loop needs a local socketpair which ``pytest-socket``
+(bundled with the HA plugin) blocks, so full integration-level tests are expected
+to run in CI on Linux. The unit-level tests in this suite are deliberately written
+without the ``hass`` fixture so they run everywhere, including a Windows dev box.
+
+To opt a future test into loading the integration, request the
+``enable_custom_integrations`` fixture provided by the plugin.
+"""
+from __future__ import annotations

--- a/tests/test_consumption_tracker.py
+++ b/tests/test_consumption_tracker.py
@@ -1,0 +1,96 @@
+"""Characterization tests for ConsumptionTracker.
+
+These pin the *current* behavior so the planned module refactors can be proven
+to change nothing. No Home Assistant entities, no Modbus, no battery: the pure
+helpers are called directly, and the one instance test uses the in-process
+``hass`` fixture plus a stand-in controller object.
+"""
+from __future__ import annotations
+
+import math
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.marstek_venus_energy_manager.const import (
+    DEFAULT_BASE_CONSUMPTION_KWH,
+)
+from custom_components.marstek_venus_energy_manager.consumption_tracker import (
+    ConsumptionTracker,
+)
+
+
+# ----------------------------------------------------------------------
+# Pure solar-energy model: get_solar_fraction_done (static, no HA needed)
+# ----------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "now_h, t_start, t_end, expected",
+    [
+        (8.0, 8.0, 16.0, 0.0),    # at sunrise -> nothing produced yet
+        (16.0, 8.0, 16.0, 1.0),   # at sunset  -> fully produced
+        (12.0, 8.0, 16.0, 0.5),   # midpoint   -> half (sinusoid is symmetric)
+        (7.0, 8.0, 16.0, 0.0),    # before window -> clamped to 0
+        (17.0, 8.0, 16.0, 1.0),   # after window  -> clamped to 1
+        (10.0, 8.0, 16.0, (1.0 - math.cos(math.pi * 0.25)) / 2.0),  # quarter way
+    ],
+)
+def test_solar_fraction_curve(now_h, t_start, t_end, expected):
+    result = ConsumptionTracker.get_solar_fraction_done(now_h, t_start, t_end)
+    assert result == pytest.approx(expected)
+
+
+def test_solar_fraction_invalid_window_returns_full():
+    # t_end <= t_start is treated as "all produced" rather than dividing by zero.
+    assert ConsumptionTracker.get_solar_fraction_done(10.0, 12.0, 12.0) == 1.0
+    assert ConsumptionTracker.get_solar_fraction_done(10.0, 12.0, 8.0) == 1.0
+
+
+# ----------------------------------------------------------------------
+# Pure formatting helper: h_to_hhmm (static, no HA needed)
+# ----------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "hours, expected",
+    [
+        (13.25, "13:15"),
+        (7.5, "07:30"),
+        (0.0, "00:00"),
+        (9.0, "09:00"),
+        (None, None),
+    ],
+)
+def test_h_to_hhmm(hours, expected):
+    assert ConsumptionTracker.h_to_hhmm(hours) == expected
+
+
+# ----------------------------------------------------------------------
+# Instance method with a mocked controller: get_avg_daily_consumption
+# Proves the controller-by-reference pattern is testable without hardware.
+# The tracker is built via __new__ so __init__ (which needs a real hass for
+# its Store objects) is skipped: this method only reads one controller attr,
+# so isolating it that way keeps the test free of the hass fixture.
+# ----------------------------------------------------------------------
+
+def _make_tracker(history):
+    """Build a tracker wired to a stand-in controller holding `history`."""
+    tracker = ConsumptionTracker.__new__(ConsumptionTracker)
+    tracker._controller = SimpleNamespace(_daily_consumption_history=history)
+    return tracker
+
+
+def test_avg_daily_consumption_empty_uses_fallback():
+    tracker = _make_tracker([])
+    assert tracker.get_avg_daily_consumption() == DEFAULT_BASE_CONSUMPTION_KWH
+
+
+def test_avg_daily_consumption_averages_history():
+    history = [(date(2026, 6, 1), 4.0), (date(2026, 6, 2), 6.0)]
+    tracker = _make_tracker(history)
+    assert tracker.get_avg_daily_consumption() == pytest.approx(5.0)
+
+
+def test_avg_daily_consumption_single_day():
+    tracker = _make_tracker([(date(2026, 6, 1), 3.0)])
+    assert tracker.get_avg_daily_consumption() == pytest.approx(3.0)


### PR DESCRIPTION
## What

Adds the project's first automated test suite and a CI workflow, replacing manual HA-UI-only validation.

This is the foundation (Tier 0) for the planned module-extraction refactors: characterization tests can now prove "no functional change" per extracted module, replacing the manual 24h soak as the merge gate.

## Contents

- **`tests/test_consumption_tracker.py`** — 15 unit tests covering the pure solar-energy model (`get_solar_fraction_done`), time formatting (`h_to_hhmm`), and average consumption (`get_avg_daily_consumption`) via a mocked controller. No hardware, no Modbus, no `hass` fixture.
- **`pytest.ini`** — disables the HA pytest plugin (`-p no:homeassistant`) so the suite runs green on Windows, where the plugin forces an event loop whose self-pipe is blocked by the bundled `pytest-socket`. The unit tests use none of the plugin's fixtures.
- **`requirements-test.txt`** — `pytest-homeassistant-custom-component` + `pymodbus` (the latter is a manifest runtime dep the test plugin does not pull).
- **`.github/workflows/tests.yml`** — runs `pytest` on every PR (Python 3.13).
- **`.gitignore`** — ignore the local `.venv-test/`.

## Verified

`15 passed` locally (Python 3.12, Windows) against both the `main` and `release/2.0.4` source trees.

## Notes

- To make CI **block** merges on red tests, enable a required status check for `pytest` in branch protection on `main`.
- Future `hass`-fixture integration tests should drop the `-p no:homeassistant` flag and run on Linux/CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
