### PR TITLE
refactor: extract PD load sharing to power_distribution.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal
 - **Automated test suite + CI**: first `pytest` coverage (consumption model, excluded-device and EV-charger logic), run on every PR. No user-facing change. [`tests/`](tests/), [`tests.yml`](.github/workflows/tests.yml).
 - **`external_loads` module extracted**: excluded-device and EV-charger logic moved out of `__init__.py` into [`external_loads.py`](custom_components/marstek_venus_energy_manager/external_loads.py); behavior unchanged, guarded by the new tests.
+- **`power_distribution` module extracted**: multi-battery load-sharing (power allocation, battery selection, split-hold rebalance) moved out of `__init__.py` into [`power_distribution.py`](custom_components/marstek_venus_energy_manager/power_distribution.py); behavior unchanged, guarded by new characterization tests.
 
 ### Changed
 - **`const.py` split into a `const/` package** (no behaviour change): per-model register/entity definitions moved to `registers_v2/v3/va/vd.py`, shared register infra to `registers_common.py`, and integration/feature constants to `integration_const.py`. `const/__init__.py` re-exports everything, so all existing imports keep working. [`const/`](custom_components/marstek_venus_energy_manager/const/).

--- a/custom_components/marstek_venus_energy_manager/__init__.py
+++ b/custom_components/marstek_venus_energy_manager/__init__.py
@@ -104,12 +104,6 @@ from .const import (
     DEFAULT_PREDICTIVE_SAFETY_MARGIN_KWH,
     CONF_PREDICTIVE_GRID_CHARGE_MARGIN_PCT,
     DEFAULT_PREDICTIVE_GRID_CHARGE_MARGIN_PCT,
-    MULTI_BATTERY_DISCHARGE_CROSSOVER_W,
-    MULTI_BATTERY_CHARGE_CROSSOVER_W,
-    MULTI_BATTERY_HYSTERESIS_GAP,
-    MULTI_BATTERY_MIN_ACTIVATION,
-    MULTI_BATTERY_MAX_ACTIVATION,
-    MULTI_BATTERY_SELECTION_HOLD_SECONDS,
     CONF_ENABLE_HOURLY_BALANCE,
     CONF_HOURLY_BALANCE_TARGET_NET_WH,
     CONF_HOURLY_BALANCE_MAX_OFFSET_W,
@@ -418,11 +412,11 @@ class ChargeDischargeController:
         self.max_charge_capacity = self._effective_system_capacity(coordinators, is_charging=True)
         self.max_discharge_capacity = self._effective_system_capacity(coordinators, is_charging=False)
 
-        # Load sharing state: track which batteries were active last cycle
+        # Load sharing state: track which batteries were active last cycle.
+        # Active-battery lists stay here (sensor.py/switch.py and the control loop
+        # read/mutate them); the wall-clock split holds live in PowerDistribution.
         self._active_discharge_batteries = []
         self._active_charge_batteries = []
-        self._discharge_selection_hold_until = {}
-        self._charge_selection_hold_until = {}
 
         # Non-responsive battery tracking: excludes batteries that ACK commands but don't deliver power
         self._non_responsive = NonResponsiveTracker()
@@ -3007,10 +3001,6 @@ class ChargeDischargeController:
 
         return (lo + hi) / 2.0
 
-    def _round_to_5w(self, value: float) -> int:
-        """Round value to nearest 5W granularity."""
-        return round(value / 5) * 5
-    
     def reset_pid_state(self):
         """Manually reset PID controller state. Useful when system is unstable."""
         _LOGGER.warning("PID: MANUAL RESET requested - clearing all PID state variables")
@@ -3554,8 +3544,8 @@ class ChargeDischargeController:
         )
 
         # Select batteries via load sharing, then distribute power
-        selected_batteries = self._select_batteries_for_operation(abs(new_power), available_batteries, is_charging=True)
-        power_allocation = self._distribute_power_by_limits(abs(new_power), selected_batteries, is_charging=True)
+        selected_batteries = self._power_distribution._select_batteries_for_operation(abs(new_power), available_batteries, is_charging=True)
+        power_allocation = self._power_distribution._distribute_power_by_limits(abs(new_power), selected_batteries, is_charging=True)
 
         total_allocated = sum(power_allocation.values())
         _LOGGER.info("Predictive: Setting charge to %dW total across %d batteries: %s",
@@ -3577,339 +3567,6 @@ class ChargeDischargeController:
         self.previous_power = new_power
         self.previous_error = error
         self.previous_sensor = sensor_filtered
-
-    def _distribute_power_by_limits(self, total_power: float, available_batteries: list, is_charging: bool) -> dict:
-        """Distribute power among batteries proportionally to their individual limits.
-
-        Returns dict mapping coordinator -> power (int, rounded to 5W).
-        """
-        if not available_batteries:
-            return {}
-
-        # Get each battery's individual limit
-        limits = {}
-        for c in available_batteries:
-            limits[c] = self._battery_power_limit(c, is_charging)
-
-        total_capacity = sum(limits.values())
-        if total_capacity <= 0:
-            return {c: 0 for c in available_batteries}
-
-        # Clamp total request to selected-battery capacity and optional system cap.
-        remaining_power = self._clamp_to_system_capacity(
-            min(total_power, total_capacity),
-            available_batteries,
-            is_charging,
-        )
-
-        allocation = {}
-        remaining_batteries = list(available_batteries)
-
-        # Iterative allocation: distribute proportionally, cap at limits, redistribute excess
-        while remaining_power > 0 and remaining_batteries:
-            current_capacity = sum(limits[c] for c in remaining_batteries)
-            if current_capacity <= 0:
-                break
-
-            all_fit = True
-            for c in list(remaining_batteries):
-                share = remaining_power * (limits[c] / current_capacity)
-                if share >= limits[c]:
-                    # This battery is at its limit
-                    allocation[c] = self._round_to_5w(limits[c])
-                    remaining_power -= limits[c]
-                    remaining_batteries.remove(c)
-                    all_fit = False
-
-            if all_fit:
-                # All remaining batteries can handle their proportional share
-                for c in remaining_batteries:
-                    share = remaining_power * (limits[c] / current_capacity)
-                    allocation[c] = self._round_to_5w(share)
-                break
-
-        # Ensure all batteries have an entry
-        for c in available_batteries:
-            if c not in allocation:
-                allocation[c] = 0
-
-        return allocation
-
-    def _select_batteries_for_operation(
-        self,
-        total_power: float,
-        available_batteries: list,
-        is_charging: bool
-    ) -> list:
-        """Select minimum batteries needed for efficient load sharing.
-
-        Activation threshold is derived per step from absolute efficiency crossover
-        wattages (where splitting across 2 batteries beats a single battery on η external):
-        - Discharge: 1500 W crossover → threshold = 1500 / this_battery_max
-        - Charge:    1750 W crossover → threshold = 1750 / this_battery_max
-        Clamped to [MIN_ACTIVATION, MAX_ACTIVATION] from const.py.
-        Using each battery's own capacity ensures correct behaviour in heterogeneous
-        setups (e.g. v3 2500 W + Venus A 1500 W).
-
-        Prioritizes:
-        - Discharge: Highest SOC first (drain fullest battery first)
-        - Charge: Lowest SOC first (fill emptiest battery first)
-
-        Hysteresis:
-        - SOC: Active batteries get 5% effective SOC advantage to avoid ping-pong
-        - Power: Deactivation threshold = activation threshold − 10 pp
-        """
-        # No power requested: clear load-sharing state. This must run before
-        # the single-battery fast path so a one-battery system is not retained
-        # as active while the controller is intentionally idle.
-        if total_power <= 0:
-            self._active_discharge_batteries = []
-            self._active_charge_batteries = []
-            self._discharge_selection_hold_until.clear()
-            self._charge_selection_hold_until.clear()
-            return []
-
-        if len(available_batteries) <= 1:
-            # Even with a single battery, update tracking state so the Active
-            # Batteries diagnostic sensor correctly reflects charging/discharging
-            # instead of always showing "Idle".
-            selected = list(available_batteries)
-            if is_charging:
-                self._active_charge_batteries = selected
-                self._active_discharge_batteries = []
-                self._discharge_selection_hold_until.clear()
-                self._charge_selection_hold_until.clear()
-            else:
-                self._active_discharge_batteries = selected
-                self._active_charge_batteries = []
-                self._discharge_selection_hold_until.clear()
-                self._charge_selection_hold_until.clear()
-            return selected
-
-        # Clamp the request to the capacity of currently available batteries.
-        total_power = self._clamp_to_system_capacity(
-            total_power,
-            available_batteries,
-            is_charging,
-        )
-
-        crossover_w = (
-            MULTI_BATTERY_CHARGE_CROSSOVER_W if is_charging
-            else MULTI_BATTERY_DISCHARGE_CROSSOVER_W
-        )
-        activation_threshold = MULTI_BATTERY_MIN_ACTIVATION  # updated per step in loop
-        SOC_HYSTERESIS = 5.0
-        ENERGY_HYSTERESIS = 2.5  # kWh advantage for active battery in tiebreaker
-
-        previous_active = (
-            self._active_charge_batteries if is_charging
-            else self._active_discharge_batteries
-        )
-        hold_until = (
-            self._charge_selection_hold_until if is_charging
-            else self._discharge_selection_hold_until
-        )
-        now = time.monotonic()
-
-        def sort_key(coordinator):
-            soc = coordinator.data.get("battery_soc", 50) if coordinator.data else 50
-            is_active = coordinator in previous_active
-
-            if is_charging:
-                # Lowest SOC first; active batteries get -5% to stay selected
-                effective_soc = soc - (SOC_HYSTERESIS if is_active else 0)
-                energy = coordinator.data.get("total_charging_energy", 0) if coordinator.data else 0
-                # Active battery gets -2.5 kWh advantage (lower = selected first)
-                effective_energy = energy - (ENERGY_HYSTERESIS if is_active else 0)
-                return (effective_soc, effective_energy)
-            else:
-                # Highest SOC first; active batteries get +5% to stay selected
-                effective_soc = soc + (SOC_HYSTERESIS if is_active else 0)
-                energy = coordinator.data.get("total_discharging_energy", 0) if coordinator.data else 0
-                # Active battery gets -2.5 kWh advantage (lower = selected first)
-                effective_energy = energy - (ENERGY_HYSTERESIS if is_active else 0)
-                return (-effective_soc, effective_energy)
-
-        sorted_batteries = sorted(available_batteries, key=sort_key)
-
-        # Select minimum batteries needed
-        selected = []
-        combined_capacity = 0
-
-        for battery in sorted_batteries:
-            selected.append(battery)
-            limit = self._battery_power_limit(battery, is_charging)
-            combined_capacity += limit
-            activation_threshold = max(
-                MULTI_BATTERY_MIN_ACTIVATION,
-                min(MULTI_BATTERY_MAX_ACTIVATION, crossover_w / limit)
-            )
-            if total_power <= combined_capacity * activation_threshold:
-                break
-
-        # Power hysteresis: avoid oscillating near the activation threshold.
-        if len(available_batteries) > 1 and previous_active:
-            # Case A — deactivation hysteresis: the loop dropped a previously-active battery.
-            # Only confirm its removal if power fell clearly below the activation threshold;
-            # otherwise re-add it so it stays active until the load genuinely drops.
-            for battery in previous_active:
-                if battery not in selected and battery in available_batteries:
-                    limit = self._battery_power_limit(battery, is_charging)
-                    first_limit = (
-                        self._battery_power_limit(selected[0], is_charging)
-                    ) if selected else limit
-                    act_thr = max(MULTI_BATTERY_MIN_ACTIVATION,
-                                  min(MULTI_BATTERY_MAX_ACTIVATION, crossover_w / first_limit))
-                    deact_thr = max(MULTI_BATTERY_MIN_ACTIVATION, act_thr - MULTI_BATTERY_HYSTERESIS_GAP)
-                    if total_power > combined_capacity * deact_thr:
-                        selected.append(battery)
-                        combined_capacity += limit
-
-            # Case B — activation hysteresis: the loop just added a battery that was not
-            # previously active.  Only commit to using it if power is clearly above the
-            # threshold; if it is near the boundary, keep a single battery to prevent
-            # rapid on/off cycling.
-            if len(selected) > 1:
-                last = selected[-1]
-                if last not in previous_active:
-                    last_limit = self._battery_power_limit(last, is_charging)
-                    capacity_without_last = combined_capacity - last_limit
-                    prev_limit = self._battery_power_limit(selected[-2], is_charging)
-                    act_thr_with_hyst = min(
-                        max(MULTI_BATTERY_MIN_ACTIVATION,
-                            min(MULTI_BATTERY_MAX_ACTIVATION, crossover_w / prev_limit))
-                        + MULTI_BATTERY_HYSTERESIS_GAP,
-                        MULTI_BATTERY_MAX_ACTIVATION,
-                    )
-                    if total_power <= capacity_without_last * act_thr_with_hyst:
-                        selected.pop()
-                        combined_capacity -= last_limit
-
-        split_condition_active = len(selected) > 1
-        hold_refreshed = set()
-
-        # Minimum split duration: when the selector decides that more than one
-        # battery should participate, refresh a wall-clock hold for every battery
-        # in the split. Deadband early returns may skip selector calls, so expiry
-        # must be time-based rather than tied to PD write cycles.
-        if split_condition_active:
-            for battery in selected:
-                hold_until[battery] = now + MULTI_BATTERY_SELECTION_HOLD_SECONDS
-                hold_refreshed.add(battery)
-
-        for battery in previous_active:
-            if (
-                battery not in selected
-                and battery in available_batteries
-                and hold_until.get(battery, 0) > now
-            ):
-                selected.append(battery)
-                held_limit = self._battery_power_limit(battery, is_charging)
-                combined_capacity += held_limit
-                remaining_seconds = math.ceil(hold_until[battery] - now)
-                _LOGGER.debug(
-                    "Load sharing [%s]: holding %s active for %d more seconds",
-                    "charge" if is_charging else "discharge",
-                    battery.name,
-                    remaining_seconds,
-                )
-
-        for battery in list(hold_until):
-            if hold_until[battery] <= now or battery not in selected:
-                hold_until.pop(battery, None)
-
-        # Log when selection changes
-        if set(selected) != set(previous_active):
-            mode = "charge" if is_charging else "discharge"
-            _LOGGER.info(
-                "Load sharing [%s]: %d/%d batteries active (%s) for %dW "
-                "(activation=%.0f%%)",
-                mode, len(selected), len(available_batteries),
-                ", ".join(c.name for c in selected), int(total_power),
-                activation_threshold * 100,
-            )
-
-        # Update tracking state: clear opposite list since charge/discharge are mutually exclusive
-        if is_charging:
-            self._active_charge_batteries = list(selected)
-            self._active_discharge_batteries = []
-            self._discharge_selection_hold_until.clear()
-        else:
-            self._active_discharge_batteries = list(selected)
-            self._active_charge_batteries = []
-            self._charge_selection_hold_until.clear()
-
-        return selected
-
-    async def _rebalance_expired_load_sharing_hold(
-        self,
-        *,
-        grid_w: float,
-        target_w: float,
-    ) -> bool:
-        """Release expired split-load holds even when the PD loop is in deadband."""
-        if self.previous_power == 0:
-            return False
-
-        is_charging = self.previous_power > 0
-        active_batteries = (
-            self._active_charge_batteries if is_charging
-            else self._active_discharge_batteries
-        )
-        if len(active_batteries) <= 1:
-            return False
-
-        hold_until = (
-            self._charge_selection_hold_until if is_charging
-            else self._discharge_selection_hold_until
-        )
-        now = time.monotonic()
-        if not any(hold_until.get(battery, 0) <= now for battery in active_batteries):
-            return False
-
-        available_batteries = self._get_available_batteries(is_charging)
-        if not available_batteries:
-            return False
-
-        selected_batteries = self._select_batteries_for_operation(
-            abs(self.previous_power),
-            available_batteries,
-            is_charging,
-        )
-        if set(selected_batteries) == set(active_batteries):
-            return False
-
-        power_allocation = self._distribute_power_by_limits(
-            abs(self.previous_power),
-            selected_batteries,
-            is_charging,
-        )
-        self._log_power_command_plan(
-            phase="hold_expired_deadband",
-            grid_w=grid_w,
-            target_w=target_w,
-            previous_power_w=self.previous_power,
-            requested_power_w=self.previous_power,
-            is_charging=is_charging,
-            available_batteries=available_batteries,
-            selected_batteries=selected_batteries,
-            power_allocation=power_allocation,
-        )
-
-        for coordinator in selected_batteries:
-            power = power_allocation.get(coordinator, 0)
-            if is_charging:
-                await self._set_battery_power(coordinator, power, 0)
-            else:
-                await self._set_battery_power(coordinator, 0, power)
-
-        for coordinator in self.coordinators:
-            if coordinator not in selected_batteries:
-                if self._is_active_balance_mode_running(coordinator):
-                    continue
-                await self._set_battery_power(coordinator, 0, 0)
-
-        return True
 
     def _log_power_command_plan(
         self,
@@ -6102,7 +5759,7 @@ class ChargeDischargeController:
             # NOTE: Do NOT clear load sharing state here. Batteries keep executing
             # their last command during deadband, so the active battery lists must
             # remain accurate for the diagnostic sensor.
-            if await self._rebalance_expired_load_sharing_hold(
+            if await self._power_distribution._rebalance_expired_load_sharing_hold(
                 grid_w=sensor_actual,
                 target_w=active_target,
             ):
@@ -6191,8 +5848,8 @@ class ChargeDischargeController:
                     self.previous_power = -limit
 
             # Select batteries via load sharing, then distribute power
-            selected_batteries = self._select_batteries_for_operation(abs(self.previous_power), available_batteries, is_charging)
-            power_allocation = self._distribute_power_by_limits(abs(self.previous_power), selected_batteries, is_charging)
+            selected_batteries = self._power_distribution._select_batteries_for_operation(abs(self.previous_power), available_batteries, is_charging)
+            power_allocation = self._power_distribution._distribute_power_by_limits(abs(self.previous_power), selected_batteries, is_charging)
 
             self._log_power_command_plan(
                 phase="initial",
@@ -6624,8 +6281,8 @@ class ChargeDischargeController:
             return
         
         # Select batteries via load sharing, then distribute power
-        selected_batteries = self._select_batteries_for_operation(abs(new_power), available_batteries, is_charging)
-        power_allocation = self._distribute_power_by_limits(abs(new_power), selected_batteries, is_charging)
+        selected_batteries = self._power_distribution._select_batteries_for_operation(abs(new_power), available_batteries, is_charging)
+        power_allocation = self._power_distribution._distribute_power_by_limits(abs(new_power), selected_batteries, is_charging)
 
         self._log_power_command_plan(
             phase="pd",
@@ -7094,6 +6751,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     from .external_loads import ExternalLoads
     controller._external_loads = ExternalLoads(hass, entry, controller)
+
+    from .power_distribution import PowerDistribution
+    controller._power_distribution = PowerDistribution(hass, entry, controller)
 
     # Restore daily consumption history: try Store first (survives reloads), then binary sensor fallback
     loaded = await consumption_tracker.load_consumption_history()

--- a/custom_components/marstek_venus_energy_manager/power_distribution.py
+++ b/custom_components/marstek_venus_energy_manager/power_distribution.py
@@ -1,0 +1,393 @@
+"""Multi-battery PD load-sharing for Marstek Venus.
+
+Owns the power-distribution algorithm extracted from ChargeDischargeController:
+- Proportional power allocation across selected batteries (capped at per-battery
+  limits, with iterative redistribution of excess).
+- Minimum-battery selection with SOC ordering, per-step activation thresholds,
+  power/SOC hysteresis, and wall-clock split-load holds.
+- Deadband hold release (re-select + re-write when a split hold expires).
+
+The split-load wall-clock holds are private to this module. The *active battery*
+lists (``_active_charge_batteries`` / ``_active_discharge_batteries``) remain on
+the controller because sensor.py, switch.py, and the main control loop read and
+mutate them; this module reads/writes them by reference via ``self._controller``.
+
+Per-battery limit and capacity primitives (``_battery_power_limit``,
+``_clamp_to_system_capacity``) stay on the controller — they are entangled with
+slot ceilings, voltage taper, and system caps — and are queried here as inputs.
+"""
+from __future__ import annotations
+
+import logging
+import math
+import time
+from typing import TYPE_CHECKING, Any
+
+from .const import (
+    MULTI_BATTERY_CHARGE_CROSSOVER_W,
+    MULTI_BATTERY_DISCHARGE_CROSSOVER_W,
+    MULTI_BATTERY_HYSTERESIS_GAP,
+    MULTI_BATTERY_MAX_ACTIVATION,
+    MULTI_BATTERY_MIN_ACTIVATION,
+    MULTI_BATTERY_SELECTION_HOLD_SECONDS,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PowerDistribution:
+    """Multi-battery load-sharing allocation and selection."""
+
+    def __init__(
+        self,
+        hass: "HomeAssistant",
+        config_entry: "ConfigEntry",
+        controller: Any,
+    ) -> None:
+        self._hass = hass
+        self._config_entry = config_entry
+        self._controller = controller
+        # Wall-clock split-load holds (private to PD load sharing).
+        self._charge_selection_hold_until = {}
+        self._discharge_selection_hold_until = {}
+
+    def _round_to_5w(self, value: float) -> int:
+        """Round value to nearest 5W granularity."""
+        return round(value / 5) * 5
+
+    def _distribute_power_by_limits(self, total_power: float, available_batteries: list, is_charging: bool) -> dict:
+        """Distribute power among batteries proportionally to their individual limits.
+
+        Returns dict mapping coordinator -> power (int, rounded to 5W).
+        """
+        if not available_batteries:
+            return {}
+
+        # Get each battery's individual limit
+        limits = {}
+        for c in available_batteries:
+            limits[c] = self._controller._battery_power_limit(c, is_charging)
+
+        total_capacity = sum(limits.values())
+        if total_capacity <= 0:
+            return {c: 0 for c in available_batteries}
+
+        # Clamp total request to selected-battery capacity and optional system cap.
+        remaining_power = self._controller._clamp_to_system_capacity(
+            min(total_power, total_capacity),
+            available_batteries,
+            is_charging,
+        )
+
+        allocation = {}
+        remaining_batteries = list(available_batteries)
+
+        # Iterative allocation: distribute proportionally, cap at limits, redistribute excess
+        while remaining_power > 0 and remaining_batteries:
+            current_capacity = sum(limits[c] for c in remaining_batteries)
+            if current_capacity <= 0:
+                break
+
+            all_fit = True
+            for c in list(remaining_batteries):
+                share = remaining_power * (limits[c] / current_capacity)
+                if share >= limits[c]:
+                    # This battery is at its limit
+                    allocation[c] = self._round_to_5w(limits[c])
+                    remaining_power -= limits[c]
+                    remaining_batteries.remove(c)
+                    all_fit = False
+
+            if all_fit:
+                # All remaining batteries can handle their proportional share
+                for c in remaining_batteries:
+                    share = remaining_power * (limits[c] / current_capacity)
+                    allocation[c] = self._round_to_5w(share)
+                break
+
+        # Ensure all batteries have an entry
+        for c in available_batteries:
+            if c not in allocation:
+                allocation[c] = 0
+
+        return allocation
+
+    def _select_batteries_for_operation(
+        self,
+        total_power: float,
+        available_batteries: list,
+        is_charging: bool
+    ) -> list:
+        """Select minimum batteries needed for efficient load sharing.
+
+        Activation threshold is derived per step from absolute efficiency crossover
+        wattages (where splitting across 2 batteries beats a single battery on η external):
+        - Discharge: 1500 W crossover → threshold = 1500 / this_battery_max
+        - Charge:    1750 W crossover → threshold = 1750 / this_battery_max
+        Clamped to [MIN_ACTIVATION, MAX_ACTIVATION] from const.py.
+        Using each battery's own capacity ensures correct behaviour in heterogeneous
+        setups (e.g. v3 2500 W + Venus A 1500 W).
+
+        Prioritizes:
+        - Discharge: Highest SOC first (drain fullest battery first)
+        - Charge: Lowest SOC first (fill emptiest battery first)
+
+        Hysteresis:
+        - SOC: Active batteries get 5% effective SOC advantage to avoid ping-pong
+        - Power: Deactivation threshold = activation threshold − 10 pp
+        """
+        # No power requested: clear load-sharing state. This must run before
+        # the single-battery fast path so a one-battery system is not retained
+        # as active while the controller is intentionally idle.
+        if total_power <= 0:
+            self._controller._active_discharge_batteries = []
+            self._controller._active_charge_batteries = []
+            self._discharge_selection_hold_until.clear()
+            self._charge_selection_hold_until.clear()
+            return []
+
+        if len(available_batteries) <= 1:
+            # Even with a single battery, update tracking state so the Active
+            # Batteries diagnostic sensor correctly reflects charging/discharging
+            # instead of always showing "Idle".
+            selected = list(available_batteries)
+            if is_charging:
+                self._controller._active_charge_batteries = selected
+                self._controller._active_discharge_batteries = []
+                self._discharge_selection_hold_until.clear()
+                self._charge_selection_hold_until.clear()
+            else:
+                self._controller._active_discharge_batteries = selected
+                self._controller._active_charge_batteries = []
+                self._discharge_selection_hold_until.clear()
+                self._charge_selection_hold_until.clear()
+            return selected
+
+        # Clamp the request to the capacity of currently available batteries.
+        total_power = self._controller._clamp_to_system_capacity(
+            total_power,
+            available_batteries,
+            is_charging,
+        )
+
+        crossover_w = (
+            MULTI_BATTERY_CHARGE_CROSSOVER_W if is_charging
+            else MULTI_BATTERY_DISCHARGE_CROSSOVER_W
+        )
+        activation_threshold = MULTI_BATTERY_MIN_ACTIVATION  # updated per step in loop
+        SOC_HYSTERESIS = 5.0
+        ENERGY_HYSTERESIS = 2.5  # kWh advantage for active battery in tiebreaker
+
+        previous_active = (
+            self._controller._active_charge_batteries if is_charging
+            else self._controller._active_discharge_batteries
+        )
+        hold_until = (
+            self._charge_selection_hold_until if is_charging
+            else self._discharge_selection_hold_until
+        )
+        now = time.monotonic()
+
+        def sort_key(coordinator):
+            soc = coordinator.data.get("battery_soc", 50) if coordinator.data else 50
+            is_active = coordinator in previous_active
+
+            if is_charging:
+                # Lowest SOC first; active batteries get -5% to stay selected
+                effective_soc = soc - (SOC_HYSTERESIS if is_active else 0)
+                energy = coordinator.data.get("total_charging_energy", 0) if coordinator.data else 0
+                # Active battery gets -2.5 kWh advantage (lower = selected first)
+                effective_energy = energy - (ENERGY_HYSTERESIS if is_active else 0)
+                return (effective_soc, effective_energy)
+            else:
+                # Highest SOC first; active batteries get +5% to stay selected
+                effective_soc = soc + (SOC_HYSTERESIS if is_active else 0)
+                energy = coordinator.data.get("total_discharging_energy", 0) if coordinator.data else 0
+                # Active battery gets -2.5 kWh advantage (lower = selected first)
+                effective_energy = energy - (ENERGY_HYSTERESIS if is_active else 0)
+                return (-effective_soc, effective_energy)
+
+        sorted_batteries = sorted(available_batteries, key=sort_key)
+
+        # Select minimum batteries needed
+        selected = []
+        combined_capacity = 0
+
+        for battery in sorted_batteries:
+            selected.append(battery)
+            limit = self._controller._battery_power_limit(battery, is_charging)
+            combined_capacity += limit
+            activation_threshold = max(
+                MULTI_BATTERY_MIN_ACTIVATION,
+                min(MULTI_BATTERY_MAX_ACTIVATION, crossover_w / limit)
+            )
+            if total_power <= combined_capacity * activation_threshold:
+                break
+
+        # Power hysteresis: avoid oscillating near the activation threshold.
+        if len(available_batteries) > 1 and previous_active:
+            # Case A — deactivation hysteresis: the loop dropped a previously-active battery.
+            # Only confirm its removal if power fell clearly below the activation threshold;
+            # otherwise re-add it so it stays active until the load genuinely drops.
+            for battery in previous_active:
+                if battery not in selected and battery in available_batteries:
+                    limit = self._controller._battery_power_limit(battery, is_charging)
+                    first_limit = (
+                        self._controller._battery_power_limit(selected[0], is_charging)
+                    ) if selected else limit
+                    act_thr = max(MULTI_BATTERY_MIN_ACTIVATION,
+                                  min(MULTI_BATTERY_MAX_ACTIVATION, crossover_w / first_limit))
+                    deact_thr = max(MULTI_BATTERY_MIN_ACTIVATION, act_thr - MULTI_BATTERY_HYSTERESIS_GAP)
+                    if total_power > combined_capacity * deact_thr:
+                        selected.append(battery)
+                        combined_capacity += limit
+
+            # Case B — activation hysteresis: the loop just added a battery that was not
+            # previously active.  Only commit to using it if power is clearly above the
+            # threshold; if it is near the boundary, keep a single battery to prevent
+            # rapid on/off cycling.
+            if len(selected) > 1:
+                last = selected[-1]
+                if last not in previous_active:
+                    last_limit = self._controller._battery_power_limit(last, is_charging)
+                    capacity_without_last = combined_capacity - last_limit
+                    prev_limit = self._controller._battery_power_limit(selected[-2], is_charging)
+                    act_thr_with_hyst = min(
+                        max(MULTI_BATTERY_MIN_ACTIVATION,
+                            min(MULTI_BATTERY_MAX_ACTIVATION, crossover_w / prev_limit))
+                        + MULTI_BATTERY_HYSTERESIS_GAP,
+                        MULTI_BATTERY_MAX_ACTIVATION,
+                    )
+                    if total_power <= capacity_without_last * act_thr_with_hyst:
+                        selected.pop()
+                        combined_capacity -= last_limit
+
+        split_condition_active = len(selected) > 1
+        hold_refreshed = set()
+
+        # Minimum split duration: when the selector decides that more than one
+        # battery should participate, refresh a wall-clock hold for every battery
+        # in the split. Deadband early returns may skip selector calls, so expiry
+        # must be time-based rather than tied to PD write cycles.
+        if split_condition_active:
+            for battery in selected:
+                hold_until[battery] = now + MULTI_BATTERY_SELECTION_HOLD_SECONDS
+                hold_refreshed.add(battery)
+
+        for battery in previous_active:
+            if (
+                battery not in selected
+                and battery in available_batteries
+                and hold_until.get(battery, 0) > now
+            ):
+                selected.append(battery)
+                held_limit = self._controller._battery_power_limit(battery, is_charging)
+                combined_capacity += held_limit
+                remaining_seconds = math.ceil(hold_until[battery] - now)
+                _LOGGER.debug(
+                    "Load sharing [%s]: holding %s active for %d more seconds",
+                    "charge" if is_charging else "discharge",
+                    battery.name,
+                    remaining_seconds,
+                )
+
+        for battery in list(hold_until):
+            if hold_until[battery] <= now or battery not in selected:
+                hold_until.pop(battery, None)
+
+        # Log when selection changes
+        if set(selected) != set(previous_active):
+            mode = "charge" if is_charging else "discharge"
+            _LOGGER.info(
+                "Load sharing [%s]: %d/%d batteries active (%s) for %dW "
+                "(activation=%.0f%%)",
+                mode, len(selected), len(available_batteries),
+                ", ".join(c.name for c in selected), int(total_power),
+                activation_threshold * 100,
+            )
+
+        # Update tracking state: clear opposite list since charge/discharge are mutually exclusive
+        if is_charging:
+            self._controller._active_charge_batteries = list(selected)
+            self._controller._active_discharge_batteries = []
+            self._discharge_selection_hold_until.clear()
+        else:
+            self._controller._active_discharge_batteries = list(selected)
+            self._controller._active_charge_batteries = []
+            self._charge_selection_hold_until.clear()
+
+        return selected
+
+    async def _rebalance_expired_load_sharing_hold(
+        self,
+        *,
+        grid_w: float,
+        target_w: float,
+    ) -> bool:
+        """Release expired split-load holds even when the PD loop is in deadband."""
+        if self._controller.previous_power == 0:
+            return False
+
+        is_charging = self._controller.previous_power > 0
+        active_batteries = (
+            self._controller._active_charge_batteries if is_charging
+            else self._controller._active_discharge_batteries
+        )
+        if len(active_batteries) <= 1:
+            return False
+
+        hold_until = (
+            self._charge_selection_hold_until if is_charging
+            else self._discharge_selection_hold_until
+        )
+        now = time.monotonic()
+        if not any(hold_until.get(battery, 0) <= now for battery in active_batteries):
+            return False
+
+        available_batteries = self._controller._get_available_batteries(is_charging)
+        if not available_batteries:
+            return False
+
+        selected_batteries = self._select_batteries_for_operation(
+            abs(self._controller.previous_power),
+            available_batteries,
+            is_charging,
+        )
+        if set(selected_batteries) == set(active_batteries):
+            return False
+
+        power_allocation = self._distribute_power_by_limits(
+            abs(self._controller.previous_power),
+            selected_batteries,
+            is_charging,
+        )
+        self._controller._log_power_command_plan(
+            phase="hold_expired_deadband",
+            grid_w=grid_w,
+            target_w=target_w,
+            previous_power_w=self._controller.previous_power,
+            requested_power_w=self._controller.previous_power,
+            is_charging=is_charging,
+            available_batteries=available_batteries,
+            selected_batteries=selected_batteries,
+            power_allocation=power_allocation,
+        )
+
+        for coordinator in selected_batteries:
+            power = power_allocation.get(coordinator, 0)
+            if is_charging:
+                await self._controller._set_battery_power(coordinator, power, 0)
+            else:
+                await self._controller._set_battery_power(coordinator, 0, power)
+
+        for coordinator in self._controller.coordinators:
+            if coordinator not in selected_batteries:
+                if self._controller._is_active_balance_mode_running(coordinator):
+                    continue
+                await self._controller._set_battery_power(coordinator, 0, 0)
+
+        return True

--- a/tests/test_power_distribution.py
+++ b/tests/test_power_distribution.py
@@ -1,28 +1,30 @@
 """Characterization tests for the PD load-sharing cluster.
 
-These pin the *current* behavior of three methods on the controller so the
-upcoming power_distribution.py extraction can be proven to change nothing:
+These pin the behavior of three methods on PowerDistribution so the extraction
+from ChargeDischargeController is proven cero-cambio-funcional:
     _distribute_power_by_limits   (proportional allocation)
     _select_batteries_for_operation (min-battery selection + hysteresis + holds)
     _rebalance_expired_load_sharing_hold (deadband hold release)
 
-No hardware, no real Home Assistant. The controller is built with
-``ChargeDischargeController.__new__`` and only the attributes/collaborators the
-three methods touch are set. The per-battery limit primitive
-``_battery_power_limit`` stays on the controller (it is NOT part of this
-extraction); it is exercised for real here but configured to resolve to an
+No hardware, no real Home Assistant. ``_build`` constructs PowerDistribution
+with a stub controller exposing only the attributes/collaborators the cluster
+reads. The per-battery limit primitives (``_battery_power_limit`` /
+``_clamp_to_system_capacity``) stay on the controller; here they resolve to an
 identity on each coordinator's ``max_charge_power`` / ``max_discharge_power``
-(no active slot, taper not applicable because ``max_soc`` < 100).
+with no system cap. The active-battery lists also live on the controller (read
+via ``pd._controller``); the wall-clock split holds live on PowerDistribution.
 
-When the cluster moves to power_distribution.py, only ``_build`` is retargeted
-to construct ``PowerDistribution`` with a stub controller; the assertions below
-stay identical, which is the cero-cambio-funcional proof.
+These same assertions ran green against the real controller before the move
+(only ``_build`` changed), which is the no-change proof.
 """
 from __future__ import annotations
 
 import time
+from types import SimpleNamespace
 
-from custom_components.marstek_venus_energy_manager import ChargeDischargeController
+from custom_components.marstek_venus_energy_manager.power_distribution import (
+    PowerDistribution,
+)
 
 
 # ----------------------------------------------------------------------
@@ -53,30 +55,44 @@ def _coord(name, limit, *, soc=50, charge_energy=0.0, discharge_energy=0.0):
 def _build(coords, *, active_charge=None, active_discharge=None,
            charge_holds=None, discharge_holds=None, previous_power=0,
            available=None, set_calls=None):
-    """Build a controller with only the attrs/collaborators the cluster reads."""
-    c = ChargeDischargeController.__new__(ChargeDischargeController)
-    c.enable_system_power_limits = False
-    c.coordinators = list(coords)
-    c.previous_power = previous_power
-    c._active_charge_batteries = list(active_charge or [])
-    c._active_discharge_batteries = list(active_discharge or [])
-    c._charge_selection_hold_until = dict(charge_holds or {})
-    c._discharge_selection_hold_until = dict(discharge_holds or {})
+    """Build a PowerDistribution with a stub controller exposing only the
+    collaborators/attrs the cluster reads.
 
-    # Collaborators that stay on the controller (excluded from this extraction),
-    # stubbed so _battery_power_limit resolves to an identity on the coordinator
-    # power attrs and the I/O paths are observable.
-    c._get_active_slot = lambda coordinator, kind: None
-    c._is_active_balance_mode_running = lambda coordinator: False
-    c._get_available_batteries = lambda is_charging, *a, **k: list(
-        available if available is not None else coords
+    ``_battery_power_limit`` and ``_clamp_to_system_capacity`` stay on the
+    controller; here they resolve to an identity on each coordinator's power
+    limit with no system cap (matching ``enable_system_power_limits=False`` in
+    the pre-extraction characterization). The active-battery lists live on the
+    controller, so assertions read them via ``pd._controller``; the wall-clock
+    split holds live on the PowerDistribution instance itself.
+    """
+    def _limit(coordinator, is_charging):
+        return coordinator.max_charge_power if is_charging else coordinator.max_discharge_power
+
+    def _clamp(power, batteries, is_charging):
+        return min(power, sum(_limit(c, is_charging) for c in batteries))
+
+    controller = SimpleNamespace(
+        previous_power=previous_power,
+        coordinators=list(coords),
+        _active_charge_batteries=list(active_charge or []),
+        _active_discharge_batteries=list(active_discharge or []),
+        _battery_power_limit=_limit,
+        _clamp_to_system_capacity=_clamp,
+        _get_available_batteries=lambda is_charging, *a, **k: list(
+            available if available is not None else coords
+        ),
+        _log_power_command_plan=lambda **k: None,
+        _is_active_balance_mode_running=lambda coordinator: False,
     )
-    c._log_power_command_plan = lambda **k: None
     if set_calls is not None:
         async def _set(coordinator, charge, discharge):
             set_calls.append((coordinator.name, charge, discharge))
-        c._set_battery_power = _set
-    return c
+        controller._set_battery_power = _set
+
+    pd = PowerDistribution(SimpleNamespace(), SimpleNamespace(data={}), controller)
+    pd._charge_selection_hold_until = dict(charge_holds or {})
+    pd._discharge_selection_hold_until = dict(discharge_holds or {})
+    return pd
 
 
 # ----------------------------------------------------------------------
@@ -147,8 +163,8 @@ def test_select_zero_power_clears_state():
     a = _coord("a", 2500)
     c = _build([a], active_discharge=[a], discharge_holds={a: time.monotonic() + 100})
     assert c._select_batteries_for_operation(0, [a], is_charging=False) == []
-    assert c._active_discharge_batteries == []
-    assert c._active_charge_batteries == []
+    assert c._controller._active_discharge_batteries == []
+    assert c._controller._active_charge_batteries == []
     assert c._discharge_selection_hold_until == {}
 
 
@@ -156,8 +172,8 @@ def test_select_single_battery_charge_sets_active():
     a = _coord("a", 2500)
     c = _build([a])
     assert c._select_batteries_for_operation(500, [a], is_charging=True) == [a]
-    assert c._active_charge_batteries == [a]
-    assert c._active_discharge_batteries == []
+    assert c._controller._active_charge_batteries == [a]
+    assert c._controller._active_discharge_batteries == []
 
 
 def test_select_discharge_low_power_picks_one_highest_soc():
@@ -165,7 +181,7 @@ def test_select_discharge_low_power_picks_one_highest_soc():
     c = _build([a, b])
     # 1000 W <= 2500*0.6 activation -> single battery, highest SOC drained first.
     assert c._select_batteries_for_operation(1000, [a, b], is_charging=False) == [a]
-    assert c._active_discharge_batteries == [a]
+    assert c._controller._active_discharge_batteries == [a]
 
 
 def test_select_discharge_high_power_picks_two_and_refreshes_holds():
@@ -173,7 +189,7 @@ def test_select_discharge_high_power_picks_two_and_refreshes_holds():
     c = _build([a, b])
     selected = c._select_batteries_for_operation(4000, [a, b], is_charging=False)
     assert set(selected) == {a, b}
-    assert set(c._active_discharge_batteries) == {a, b}
+    assert set(c._controller._active_discharge_batteries) == {a, b}
     # Split-load holds refreshed into the future for both batteries.
     now = time.monotonic()
     assert set(c._discharge_selection_hold_until) == {a, b}
@@ -184,7 +200,7 @@ def test_select_charge_picks_lowest_soc_first():
     a, b = _coord("a", 2500, soc=20), _coord("b", 2500, soc=80)
     c = _build([a, b])
     assert c._select_batteries_for_operation(1000, [a, b], is_charging=True) == [a]
-    assert c._active_charge_batteries == [a]
+    assert c._controller._active_charge_batteries == [a]
 
 
 def test_select_deactivation_hysteresis_retains_active_battery():
@@ -199,7 +215,7 @@ def test_select_below_deactivation_drops_active_battery():
     c = _build([a, b], active_discharge=[a, b])
     # 1000 W is below deactivation (1250) and b is not held -> dropped.
     assert c._select_batteries_for_operation(1000, [a, b], is_charging=False) == [a]
-    assert c._active_discharge_batteries == [a]
+    assert c._controller._active_discharge_batteries == [a]
 
 
 def test_select_wallclock_hold_retains_dropped_battery():

--- a/tests/test_power_distribution.py
+++ b/tests/test_power_distribution.py
@@ -1,0 +1,251 @@
+"""Characterization tests for the PD load-sharing cluster.
+
+These pin the *current* behavior of three methods on the controller so the
+upcoming power_distribution.py extraction can be proven to change nothing:
+    _distribute_power_by_limits   (proportional allocation)
+    _select_batteries_for_operation (min-battery selection + hysteresis + holds)
+    _rebalance_expired_load_sharing_hold (deadband hold release)
+
+No hardware, no real Home Assistant. The controller is built with
+``ChargeDischargeController.__new__`` and only the attributes/collaborators the
+three methods touch are set. The per-battery limit primitive
+``_battery_power_limit`` stays on the controller (it is NOT part of this
+extraction); it is exercised for real here but configured to resolve to an
+identity on each coordinator's ``max_charge_power`` / ``max_discharge_power``
+(no active slot, taper not applicable because ``max_soc`` < 100).
+
+When the cluster moves to power_distribution.py, only ``_build`` is retargeted
+to construct ``PowerDistribution`` with a stub controller; the assertions below
+stay identical, which is the cero-cambio-funcional proof.
+"""
+from __future__ import annotations
+
+import time
+
+from custom_components.marstek_venus_energy_manager import ChargeDischargeController
+
+
+# ----------------------------------------------------------------------
+# Test doubles
+# ----------------------------------------------------------------------
+
+class _Coord:
+    """A coordinator stand-in. Identity-hashable (used as dict keys), unlike
+    SimpleNamespace which defines __eq__ and is therefore unhashable.
+    max_soc<100 keeps the charge limit at identity (taper not applicable)."""
+
+    def __init__(self, name, limit, soc, charge_energy, discharge_energy):
+        self.name = name
+        self.max_charge_power = limit
+        self.max_discharge_power = limit
+        self.max_soc = 80
+        self.data = {
+            "battery_soc": soc,
+            "total_charging_energy": charge_energy,
+            "total_discharging_energy": discharge_energy,
+        }
+
+
+def _coord(name, limit, *, soc=50, charge_energy=0.0, discharge_energy=0.0):
+    return _Coord(name, limit, soc, charge_energy, discharge_energy)
+
+
+def _build(coords, *, active_charge=None, active_discharge=None,
+           charge_holds=None, discharge_holds=None, previous_power=0,
+           available=None, set_calls=None):
+    """Build a controller with only the attrs/collaborators the cluster reads."""
+    c = ChargeDischargeController.__new__(ChargeDischargeController)
+    c.enable_system_power_limits = False
+    c.coordinators = list(coords)
+    c.previous_power = previous_power
+    c._active_charge_batteries = list(active_charge or [])
+    c._active_discharge_batteries = list(active_discharge or [])
+    c._charge_selection_hold_until = dict(charge_holds or {})
+    c._discharge_selection_hold_until = dict(discharge_holds or {})
+
+    # Collaborators that stay on the controller (excluded from this extraction),
+    # stubbed so _battery_power_limit resolves to an identity on the coordinator
+    # power attrs and the I/O paths are observable.
+    c._get_active_slot = lambda coordinator, kind: None
+    c._is_active_balance_mode_running = lambda coordinator: False
+    c._get_available_batteries = lambda is_charging, *a, **k: list(
+        available if available is not None else coords
+    )
+    c._log_power_command_plan = lambda **k: None
+    if set_calls is not None:
+        async def _set(coordinator, charge, discharge):
+            set_calls.append((coordinator.name, charge, discharge))
+        c._set_battery_power = _set
+    return c
+
+
+# ----------------------------------------------------------------------
+# _distribute_power_by_limits
+# ----------------------------------------------------------------------
+
+def test_distribute_no_batteries_is_empty():
+    c = _build([])
+    assert c._distribute_power_by_limits(1000, [], is_charging=False) == {}
+
+
+def test_distribute_two_equal_even_split():
+    a, b = _coord("a", 1000), _coord("b", 1000)
+    c = _build([a, b])
+    assert c._distribute_power_by_limits(1000, [a, b], is_charging=False) == {a: 500, b: 500}
+
+
+def test_distribute_request_over_capacity_clamps_to_limits():
+    a, b = _coord("a", 1000), _coord("b", 1000)
+    c = _build([a, b])
+    # 5000 W requested, 2000 W available -> each pinned to its 1000 W limit.
+    assert c._distribute_power_by_limits(5000, [a, b], is_charging=False) == {a: 1000, b: 1000}
+
+
+def test_distribute_uneven_limits_at_full_capacity():
+    a, b = _coord("a", 1500), _coord("b", 500)
+    c = _build([a, b])
+    assert c._distribute_power_by_limits(2000, [a, b], is_charging=False) == {a: 1500, b: 500}
+
+
+def test_distribute_uneven_limits_proportional_share():
+    a, b = _coord("a", 1500), _coord("b", 500)
+    c = _build([a, b])
+    # 1000 W < 2000 W capacity -> proportional: 75% / 25%.
+    assert c._distribute_power_by_limits(1000, [a, b], is_charging=False) == {a: 750, b: 250}
+
+
+def test_distribute_single_battery_partial():
+    a = _coord("a", 1000)
+    c = _build([a])
+    assert c._distribute_power_by_limits(600, [a], is_charging=False) == {a: 600}
+
+
+def test_distribute_zero_capacity_returns_zeros():
+    a = _coord("a", 0)
+    c = _build([a])
+    assert c._distribute_power_by_limits(500, [a], is_charging=False) == {a: 0}
+
+
+def test_distribute_rounds_to_5w():
+    a, b = _coord("a", 1000), _coord("b", 1000)
+    c = _build([a, b])
+    # 996/2 = 498 -> rounds to nearest 5 W = 500.
+    assert c._distribute_power_by_limits(996, [a, b], is_charging=False) == {a: 500, b: 500}
+
+
+def test_distribute_charge_path_is_identity_on_limit():
+    a, b = _coord("a", 1000), _coord("b", 1000)
+    c = _build([a, b])
+    assert c._distribute_power_by_limits(1000, [a, b], is_charging=True) == {a: 500, b: 500}
+
+
+# ----------------------------------------------------------------------
+# _select_batteries_for_operation
+# ----------------------------------------------------------------------
+
+def test_select_zero_power_clears_state():
+    a = _coord("a", 2500)
+    c = _build([a], active_discharge=[a], discharge_holds={a: time.monotonic() + 100})
+    assert c._select_batteries_for_operation(0, [a], is_charging=False) == []
+    assert c._active_discharge_batteries == []
+    assert c._active_charge_batteries == []
+    assert c._discharge_selection_hold_until == {}
+
+
+def test_select_single_battery_charge_sets_active():
+    a = _coord("a", 2500)
+    c = _build([a])
+    assert c._select_batteries_for_operation(500, [a], is_charging=True) == [a]
+    assert c._active_charge_batteries == [a]
+    assert c._active_discharge_batteries == []
+
+
+def test_select_discharge_low_power_picks_one_highest_soc():
+    a, b = _coord("a", 2500, soc=90), _coord("b", 2500, soc=50)
+    c = _build([a, b])
+    # 1000 W <= 2500*0.6 activation -> single battery, highest SOC drained first.
+    assert c._select_batteries_for_operation(1000, [a, b], is_charging=False) == [a]
+    assert c._active_discharge_batteries == [a]
+
+
+def test_select_discharge_high_power_picks_two_and_refreshes_holds():
+    a, b = _coord("a", 2500, soc=90), _coord("b", 2500, soc=50)
+    c = _build([a, b])
+    selected = c._select_batteries_for_operation(4000, [a, b], is_charging=False)
+    assert set(selected) == {a, b}
+    assert set(c._active_discharge_batteries) == {a, b}
+    # Split-load holds refreshed into the future for both batteries.
+    now = time.monotonic()
+    assert set(c._discharge_selection_hold_until) == {a, b}
+    assert all(t > now for t in c._discharge_selection_hold_until.values())
+
+
+def test_select_charge_picks_lowest_soc_first():
+    a, b = _coord("a", 2500, soc=20), _coord("b", 2500, soc=80)
+    c = _build([a, b])
+    assert c._select_batteries_for_operation(1000, [a, b], is_charging=True) == [a]
+    assert c._active_charge_batteries == [a]
+
+
+def test_select_deactivation_hysteresis_retains_active_battery():
+    a, b = _coord("a", 2500, soc=90), _coord("b", 2500, soc=50)
+    c = _build([a, b], active_discharge=[a, b])
+    # 1400 W is below activation (1500) but above deactivation (1250) -> b retained.
+    assert set(c._select_batteries_for_operation(1400, [a, b], is_charging=False)) == {a, b}
+
+
+def test_select_below_deactivation_drops_active_battery():
+    a, b = _coord("a", 2500, soc=90), _coord("b", 2500, soc=50)
+    c = _build([a, b], active_discharge=[a, b])
+    # 1000 W is below deactivation (1250) and b is not held -> dropped.
+    assert c._select_batteries_for_operation(1000, [a, b], is_charging=False) == [a]
+    assert c._active_discharge_batteries == [a]
+
+
+def test_select_wallclock_hold_retains_dropped_battery():
+    a, b = _coord("a", 2500, soc=90), _coord("b", 2500, soc=50)
+    c = _build([a, b], active_discharge=[a, b],
+               discharge_holds={b: time.monotonic() + 100})
+    # Power would drop b, but its wall-clock hold has not expired -> retained.
+    assert set(c._select_batteries_for_operation(500, [a, b], is_charging=False)) == {a, b}
+
+
+# ----------------------------------------------------------------------
+# _rebalance_expired_load_sharing_hold  (async)
+# ----------------------------------------------------------------------
+
+async def test_rebalance_noop_when_idle():
+    a, b = _coord("a", 2500), _coord("b", 2500)
+    calls = []
+    c = _build([a, b], previous_power=0, set_calls=calls)
+    assert await c._rebalance_expired_load_sharing_hold(grid_w=0, target_w=0) is False
+    assert calls == []
+
+
+async def test_rebalance_noop_with_single_active_battery():
+    a, b = _coord("a", 2500), _coord("b", 2500)
+    calls = []
+    c = _build([a, b], previous_power=-1000, active_discharge=[a], set_calls=calls)
+    assert await c._rebalance_expired_load_sharing_hold(grid_w=0, target_w=0) is False
+    assert calls == []
+
+
+async def test_rebalance_noop_while_holds_unexpired():
+    a, b = _coord("a", 2500, soc=90), _coord("b", 2500, soc=50)
+    calls = []
+    c = _build([a, b], previous_power=-1000, active_discharge=[a, b],
+               discharge_holds={a: time.monotonic() + 100, b: time.monotonic() + 100},
+               set_calls=calls)
+    assert await c._rebalance_expired_load_sharing_hold(grid_w=0, target_w=0) is False
+    assert calls == []
+
+
+async def test_rebalance_releases_expired_hold_and_rewrites():
+    a, b = _coord("a", 2500, soc=90), _coord("b", 2500, soc=50)
+    calls = []
+    c = _build([a, b], previous_power=-500, active_discharge=[a, b],
+               discharge_holds={a: time.monotonic() - 1, b: time.monotonic() - 1},
+               set_calls=calls)
+    # Holds expired and load now fits one battery -> reselect to [a], rewrite both.
+    assert await c._rebalance_expired_load_sharing_hold(grid_w=-500, target_w=0) is True
+    assert calls == [("a", 0, 500), ("b", 0, 0)]


### PR DESCRIPTION
## Module 6 of the incremental refactor: `power_distribution.py`

Extracts the multi-battery PD load-sharing cluster from the
`ChargeDischargeController` monolith with **cero cambio funcional**, proven by
characterization tests written first and retargeted to the module.

### Moved to `power_distribution.py`
- `_distribute_power_by_limits` — proportional allocation, iterative cap + redistribute
- `_select_batteries_for_operation` — min-battery selection, SOC ordering, power/SOC hysteresis, split holds
- `_rebalance_expired_load_sharing_hold` — deadband split-hold release
- `_round_to_5w` helper (only consumer was the allocator)
- `_charge/_discharge_selection_hold_until` wall-clock holds (cluster-private)

### Stays on the controller (queried as inputs / shared state)
- `_battery_power_limit`, `_clamp_to_system_capacity` and friends — entangled with slot ceilings, voltage taper, system caps
- `_get_available_batteries` — roadmap-excluded
- `_active_charge_batteries` / `_active_discharge_batteries` — read/mutated by sensor.py, switch.py, and the control loop; accessed via `self._controller`

### Tests
`tests/test_power_distribution.py` (21 cases) pinned current behavior against the
real controller, then retargeted to `PowerDistribution` with identical
assertions. Full suite: 63 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
