### PR TITLE
Fix: transient no-forecast no longer disables Solar Charge Delay for the whole day

### DIFF
--- a/custom_components/marstek_venus_energy_manager/charge_delay.py
+++ b/custom_components/marstek_venus_energy_manager/charge_delay.py
@@ -40,6 +40,14 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Unlock reasons that are fail-safe responses to missing/transient data, not a
+# real "charging is legitimately allowed" decision. These must NOT latch the
+# permanent daily unlock: otherwise a momentary gap (e.g. the solar-forecast
+# sensor going unavailable at the midnight rollover) silently disables the
+# charge delay for the rest of the day. Keeping them re-evaluable lets the delay
+# re-arm as soon as the data comes back.
+_TRANSIENT_UNLOCK_REASONS = frozenset({"no_forecast"})
+
 
 class ChargeDelayManager:
     """Manages the unified charge-delay gate, persistence and projection."""
@@ -203,7 +211,14 @@ class ChargeDelayManager:
         if self._should_delay_charge(target_soc):
             return True  # Keep delay active (block charging)
 
-        # Delay conditions no longer met - unlock permanently for today
+        # A fail-safe unlock from missing/transient data (e.g. the forecast
+        # sensor briefly unavailable at the midnight rollover) must stay
+        # re-evaluable so the delay re-arms once the data returns. Allow
+        # charging for this cycle, but do not latch the permanent daily unlock.
+        if ctrl._charge_delay_status.get("unlock_reason") in _TRANSIENT_UNLOCK_REASONS:
+            return False
+
+        # Delay conditions genuinely no longer met - unlock permanently for today
         ctrl._charge_delay_unlocked = True
         self.schedule_save()
         _LOGGER.info("Charge Delay: Unlocked (target_soc=%d%%) - charging now allowed", target_soc)

--- a/tests/test_charge_delay.py
+++ b/tests/test_charge_delay.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 
 from custom_components.marstek_venus_energy_manager.charge_delay import (
     ChargeDelayManager,
+    _TRANSIENT_UNLOCK_REASONS,
 )
 from custom_components.marstek_venus_energy_manager.const import (
     DELAY_SOC_SETPOINT_HYSTERESIS,
@@ -151,6 +152,50 @@ def test_keep_delay_when_should_delay_true():
     mgr._should_delay_charge = lambda target: True
     assert mgr.is_charge_delayed() is True
     assert ctrl._charge_delay_unlocked is False
+
+
+def test_transient_no_forecast_does_not_latch():
+    # A fail-safe unlock (no forecast available) allows charging this cycle but
+    # must NOT latch the permanent daily unlock, so it can re-arm later.
+    assert "no_forecast" in _TRANSIENT_UNLOCK_REASONS
+    ctrl = _controller(solar_forecast_sensor=None)
+    mgr = _make_mgr(ctrl)
+    assert mgr.is_charge_delayed() is False
+    assert ctrl._charge_delay_status["unlock_reason"] == "no_forecast"
+    assert ctrl._charge_delay_unlocked is False
+    assert mgr.saves == 0  # nothing latched, nothing persisted
+
+
+def test_delay_rearms_after_forecast_recovers():
+    # First cycle: forecast unavailable past grace -> no_forecast unlock (not latched).
+    from time import monotonic
+    ctrl = _controller(
+        _forecast_unavailable_since=monotonic() - 10_000,
+        _forecast_grace_s=300,
+    )
+    mgr = _make_mgr(ctrl, states={"sensor.forecast": _state("unavailable")})
+    assert mgr.is_charge_delayed() is False
+    assert ctrl._charge_delay_unlocked is False
+    # Next cycle the forecast is healthy again and the day is covered -> the
+    # delay re-arms instead of staying disabled for the rest of the day.
+    mgr._should_delay_charge = lambda target: True
+    assert mgr.is_charge_delayed() is True
+    assert ctrl._charge_delay_unlocked is False
+
+
+def test_genuine_unlock_still_latches():
+    # A real "conditions met" unlock (e.g. time_backup) keeps latching as before.
+    ctrl = _controller()
+    mgr = _make_mgr(ctrl)
+
+    def _stub(target):
+        ctrl._charge_delay_status["unlock_reason"] = "time_backup"
+        return False
+
+    mgr._should_delay_charge = _stub
+    assert mgr.is_charge_delayed() is False
+    assert ctrl._charge_delay_unlocked is True
+    assert mgr.saves == 1
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## What

A `no_forecast` unlock is a fail-safe for missing data, but it was latched as a permanent daily unlock just like a genuine "charging now allowed" decision. So a brief forecast-sensor gap disables Solar Charge Delay for the rest of the day, even after the forecast comes back.

## Why it bit me

My `solar_forecast_sensor` (Forecast.Solar `energy_production_tomorrow_total`) goes `unknown` for a few minutes at the midnight rollover when it recomputes. That gap outlasts the 5 min `_forecast_grace_s`, so `_should_delay_charge` returns `no_forecast`, `is_charge_delayed` latches `_charge_delay_unlocked = True`, and every later cycle short-circuits at the `if ctrl._charge_delay_unlocked:` check. The forecast recovered seconds later (full day, +10 kWh net solar), but the delay stayed off all morning and the battery charged early instead of holding for the cheap midday window.

Observed timeline (v2.0.5):

- `00:00:50` forecast sensor → `unknown` (midnight rollover)
- `00:01` "Waiting for forecast" (inside grace, correct)
- `00:06` grace expired → `Unlocking (no_forecast)`, latched
- rest of morning: "Charging allowed" despite the forecast being healthy again

The grace comment already flags this risk; the grace window just can't cover the rollover, and the unlock it guards is irreversible for the day.

## Fix

Treat fail-safe unlocks from missing/transient data (`no_forecast`) as re-evaluable instead of latching them. Charging is still allowed for that cycle (fail-safe preserved), but the permanent daily latch is only set for genuine unlocks, so the delay re-arms as soon as the forecast returns. Genuine reasons (`time_backup`, `energy_balance`, `batteries_full`, ...) latch exactly as before.

Scoped to `no_forecast` only. `low_forecast` / `no_charge_power` are left latching to keep the change minimal; happy to extend if you'd prefer.

## Tests

Added 3 cases to `test_charge_delay.py`: transient `no_forecast` doesn't latch, delay re-arms after the forecast recovers, genuine unlock still latches. Full suite: 219 passed.
