### PR TITLE
Release PV-surplus charging at the cheapest price hour

### DIFF
--- a/custom_components/marstek_venus_energy_manager/charge_delay.py
+++ b/custom_components/marstek_venus_energy_manager/charge_delay.py
@@ -465,9 +465,77 @@ class ChargeDelayManager:
             )
             return _unlock("time_backup")
 
+        # --- Price-aware release (within the proven-feasible window only) ---
+        # The checks above keep the delay until the feasibility edge
+        # (energy_balance / time_backup), which is the LATEST safe release and is
+        # often a pricier afternoon hour than the midday export trough. Pull the
+        # release FORWARD to the cheapest export hour inside the still-feasible
+        # window [now, est_unlock_h], so self-charging sacrifices the least export
+        # (teruglever) revenue. SOC target stays fully protected: the window never
+        # extends past the edge, and the hard energy/time unlocks above remain the
+        # floor. Degrades to legacy edge-release when no price data is available.
+        release_h = self._price_optimal_release_h(now_h, est_unlock_h)
+        if release_h is not None:
+            if now_h + 1e-6 < release_h:
+                # A cheaper feasible hour lies ahead, keep holding for it.
+                status["estimated_unlock_time"] = _h_to_hhmm(release_h)
+                status["state"] = f"Delayed (price, {_h_to_hhmm(release_h)} est.)"
+                return True
+            # Current hour is the cheapest feasible export hour, release now.
+            _LOGGER.info(
+                "Charge Delay: now (%.2fh) is cheapest feasible export hour up to "
+                "%.2fh - unlocking (reason: price_optimal)",
+                now_h, est_unlock_h,
+            )
+            return _unlock("price_optimal")
+
         # All checks passed - keep delay active
         status["state"] = f"Delayed ({status['estimated_unlock_time']} est.)"
         return True
+
+    def _price_optimal_release_h(self, now_h: float, edge_h: float) -> float | None:
+        """Cheapest export hour to begin charging within [now_h, edge_h].
+
+        Returns the start hour (float, today) of the lowest-priced price slot whose
+        start lies in the still-feasible window. Returns ``now_h`` when the current
+        slot is itself the cheapest (within a small epsilon, so we never hold for a
+        negligible gain). Returns ``None`` when no usable price data exists, in
+        which case the caller keeps the legacy edge-release behaviour.
+
+        This only ever moves the release EARLIER than the feasibility edge; it never
+        defers past it, so the SOC-target safety margin enforced upstream is intact.
+        """
+        ctrl = self._controller
+        pricing = getattr(ctrl, "_pricing_mgr", None)
+        if pricing is None or not getattr(ctrl, "price_sensor", None):
+            return None
+        try:
+            # Already today-only and future-only (slot.end > now); quiet so this
+            # per-cycle poll does not spam the price-parse log.
+            slots = pricing.get_future_price_slots()
+        except Exception:  # defensive: a price-parse failure must not break the delay gate
+            _LOGGER.debug("Charge Delay: price parse failed, skipping price-aware release", exc_info=True)
+            return None
+        if not slots:
+            return None
+
+        candidates = []  # (start_hour, price)
+        cur_price = None
+        for s in slots:
+            s_h = s.start.hour + s.start.minute / 60.0
+            if s_h > edge_h + 1e-6:  # slot starts after the feasibility edge
+                continue
+            candidates.append((s_h, s.price))
+            if s_h <= now_h + 1e-9:  # slot covering the current moment
+                cur_price = s.price
+        if not candidates:
+            return None
+
+        eps = 0.005  # EUR/kWh: ignore sub-cent differences, prefer releasing sooner
+        best_h, best_p = min(candidates, key=lambda c: (c[1], c[0]))
+        if cur_price is not None and cur_price <= best_p + eps:
+            return now_h
+        return best_h
 
     def _estimate_energy_balance_unlock_h(
         self,

--- a/custom_components/marstek_venus_energy_manager/pricing/engine.py
+++ b/custom_components/marstek_venus_energy_manager/pricing/engine.py
@@ -133,21 +133,32 @@ class PricingManager:
         except (ValueError, TypeError):
             return None
 
-    def _parse_price_data(self, *, horizon_end=None) -> list:
+    def get_future_price_slots(self, horizon_end=None) -> list:
+        """Public accessor for parsed future PriceSlots (today, future-only).
+
+        Thin, quiet wrapper around :meth:`_parse_price_data` for other managers
+        (e.g. the charge-delay price-aware release) that poll prices every control
+        cycle and must not spam the log. Logging is demoted to debug level here.
+        """
+        return self._parse_price_data(horizon_end=horizon_end, quiet=True)
+
+    def _parse_price_data(self, *, horizon_end=None, quiet=False) -> list:
         """Read price sensor and return list[PriceSlot] for remaining slots up to horizon_end.
 
         Dispatches to the correct parser based on price_integration_type.
         When horizon_end is None, defaults to end of current day (today 23:59:59).
-        Returns empty list on error.
+        Returns empty list on error. When quiet=True, status logging is demoted to
+        debug so high-frequency callers do not spam the log.
         """
+        _warn = _LOGGER.debug if quiet else _LOGGER.warning
         if not self._controller.price_sensor:
-            _LOGGER.warning("Dynamic pricing: no price sensor configured")
+            _warn("Dynamic pricing: no price sensor configured")
             self._controller._price_data_status = "no_sensor"
             return []
 
         state = self._hass.states.get(self._controller.price_sensor)
         if state is None or state.state in ("unknown", "unavailable"):
-            _LOGGER.warning("Dynamic pricing: price sensor %s unavailable", self._controller.price_sensor)
+            _warn("Dynamic pricing: price sensor %s unavailable", self._controller.price_sensor)
             self._controller._price_data_status = "sensor_unavailable"
             return []
 
@@ -165,7 +176,7 @@ class PricingManager:
             raw_slots = calculations.parse_nordpool_prices(attrs)
 
         if not raw_slots:
-            _LOGGER.warning(
+            _warn(
                 "Dynamic pricing: no price data parsed from %s (integration=%s)",
                 self._controller.price_sensor, self._controller.price_integration_type
             )
@@ -180,7 +191,9 @@ class PricingManager:
         effective_horizon = horizon_end if horizon_end is not None else end_of_day
         filtered = [s for s in raw_slots if s.end > now and s.start <= effective_horizon]
         self._controller._price_data_status = f"ok ({len(filtered)} slots)"
-        _LOGGER.info("Dynamic pricing: parsed %d slots (%d within horizon)", len(raw_slots), len(filtered))
+        (_LOGGER.debug if quiet else _LOGGER.info)(
+            "Dynamic pricing: parsed %d slots (%d within horizon)", len(raw_slots), len(filtered)
+        )
         return filtered
 
     # =========================================================================

--- a/tests/test_charge_delay.py
+++ b/tests/test_charge_delay.py
@@ -312,3 +312,78 @@ def test_daily_reset_first_cycle_preserves_restored_unlock():
     mgr.handle_daily_reset_and_eval()
     assert ctrl._charge_delay_unlocked is True
     assert ctrl._charge_delay_last_date == date.today()
+
+
+# ----------------------------------------------------------------------
+# _price_optimal_release_h: price-aware release within the feasible window
+# ----------------------------------------------------------------------
+from datetime import timedelta  # noqa: E402
+
+from homeassistant.util import dt as dt_util  # noqa: E402
+
+from custom_components.marstek_venus_energy_manager.pricing import (  # noqa: E402
+    PriceSlot,
+)
+
+
+def _slot(hour, price):
+    """Hourly PriceSlot for today at ``hour`` (matches the manager's today check)."""
+    start = dt_util.now().replace(
+        hour=int(hour), minute=0, second=0, microsecond=0
+    )
+    return PriceSlot(start=start, end=start + timedelta(hours=1), price=price)
+
+
+def _price_ctrl(slots, **overrides):
+    return _controller(
+        price_sensor="sensor.price",
+        _pricing_mgr=SimpleNamespace(get_future_price_slots=lambda horizon_end=None: slots),
+        **overrides,
+    )
+
+
+def test_price_release_none_without_sensor():
+    # No price_sensor / pricing manager → legacy edge release (returns None).
+    mgr = _make_mgr(_controller())
+    assert mgr._price_optimal_release_h(11.0, 16.0) is None
+
+
+def test_price_release_none_on_empty_slots():
+    mgr = _make_mgr(_price_ctrl([]))
+    assert mgr._price_optimal_release_h(11.0, 16.0) is None
+
+
+def test_price_release_holds_for_cheaper_hour_ahead():
+    # Cheapest feasible hour is 13:00 (the trough); at 11:00 with edge 16:00 → hold.
+    slots = [_slot(11, 0.21), _slot(12, 0.17), _slot(13, 0.14), _slot(14, 0.18)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._price_optimal_release_h(11.0, 16.0) == 13.0
+
+
+def test_price_release_now_when_current_is_cheapest():
+    slots = [_slot(11, 0.14), _slot(12, 0.17), _slot(13, 0.21)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._price_optimal_release_h(11.0, 16.0) == 11.0
+
+
+def test_price_release_ignores_slots_past_edge():
+    # The 13:00 trough sits past the feasibility edge (12.5) → unreachable, so the
+    # cheapest *feasible* hour (12:00) wins. This is today's tight-solar shape: the
+    # edge precedes the trough, so the trough cannot be captured without risking SOC.
+    slots = [_slot(11, 0.21), _slot(12, 0.17), _slot(13, 0.14)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._price_optimal_release_h(11.0, 12.5) == 12.0
+
+
+def test_price_release_epsilon_prefers_releasing_now():
+    # A negligibly-cheaper hour ahead (< 0.005 €/kWh) must not trigger a hold.
+    slots = [_slot(11, 0.150), _slot(13, 0.147)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._price_optimal_release_h(11.0, 16.0) == 11.0
+
+
+def test_price_release_counts_current_partial_hour():
+    # Called mid-hour (11:30): the 11:00 slot still covers now and counts as current.
+    slots = [_slot(11, 0.14), _slot(12, 0.20)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._price_optimal_release_h(11.5, 16.0) == 11.5


### PR DESCRIPTION
When the charge delay holds to soak up PV surplus, it releases at the latest feasible moment, the energy/time backstop. On a sunny day that backstop is often a pricier hour than the midday price trough, so the battery ends up charging while export is still worth more than it will be an hour or two later.

This pulls the release forward to the cheapest price hour inside the window that's already proven feasible. The battery still fills to target by sunset; it just starts during the cheapest hour it can, so self-charging gives up the least export value.

Notes:
- Opt-in by data, not config. No price sensor, no dynamic prices, or no parseable slots and it returns `None`, keeping the exact current edge-release. Fixed-tariff and no-PV setups see no change.
- The window never extends past the existing feasibility edge, so the SOC-target safety margin is untouched. It only ever moves the release *earlier*, never later.
- On tight-solar days (edge before the trough) the trough is unreachable, and it correctly releases at the cheapest *feasible* hour, usually right away.
- Adds a quiet `PricingManager.get_future_price_slots()` so the per-cycle delay poll doesn't spam the price-parse log.

All existing charge-delay characterization tests pass unchanged; added 7 covering the new release logic.